### PR TITLE
 Add a simple HTTP client wrapper for connecting to symws

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,7 @@ gem 'bootsnap', '>= 1.1.0', require: false
 gem 'honeybadger'
 
 gem 'config'
+gem 'http'
 
 gem 'okcomputer'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -107,6 +107,8 @@ GEM
       capistrano-one_time_key
       capistrano-shared_configs
     docile (1.3.2)
+    domain_name (0.5.20190701)
+      unf (>= 0.0.5, < 1.0.0)
     dry-configurable (0.8.3)
       concurrent-ruby (~> 1.0)
       dry-core (~> 0.4, >= 0.4.7)
@@ -144,6 +146,15 @@ GEM
       activesupport (>= 4.2.0)
     hashdiff (0.4.0)
     honeybadger (4.3.1)
+    http (4.1.1)
+      addressable (~> 2.3)
+      http-cookie (~> 1.0)
+      http-form_data (~> 2.0)
+      http_parser.rb (~> 0.6.0)
+    http-cookie (1.0.3)
+      domain_name (~> 0.5)
+    http-form_data (2.1.1)
+    http_parser.rb (0.6.0)
     i18n (1.6.0)
       concurrent-ruby (~> 1.0)
     jaro_winkler (1.5.3)
@@ -310,6 +321,9 @@ GEM
       thread_safe (~> 0.1)
     uglifier (4.1.20)
       execjs (>= 0.3.0, < 3)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.6)
     unicode-display_width (1.6.0)
     web-console (3.7.0)
       actionview (>= 5.0)
@@ -344,6 +358,7 @@ DEPENDENCIES
   config
   dlss-capistrano
   honeybadger
+  http
   jbuilder (~> 2.5)
   jquery-rails
   listen (>= 3.0.5, < 3.2)

--- a/app/services/symphony_client.rb
+++ b/app/services/symphony_client.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+# HTTP client wrapper for making requests to Symws
+class SymphonyClient
+  DEFAULT_HEADERS = {
+    accept: 'application/json',
+    content_type: 'application/json'
+  }.freeze
+
+  # ping the symphony endpoint to make sure we can establish a connection
+  def ping
+    session_token.present?
+  rescue HTTP::Error
+    false
+  end
+
+  # get a session token by authenticating to symws
+  def session_token
+    @session_token ||= begin
+      response = request('/user/staff/login', json: Settings.symws.login_params, method: :post)
+
+      JSON.parse(response.body)['sessionToken']
+    end
+  end
+
+  private
+
+  def authenticated_request(path, headers: {}, **other)
+    request(path, headers.merge('x-sirs-sessionToken': session_token), **other)
+  end
+
+  def request(path, headers: {}, method: :get, **other)
+    HTTP
+      .headers(default_headers.merge(headers))
+      .request(method, base_url + path, **other)
+  end
+
+  def base_url
+    Settings.symws.url
+  end
+
+  def default_headers
+    DEFAULT_HEADERS.merge(Settings.symws.headers || {})
+  end
+end

--- a/config/initializers/okcomputer.rb
+++ b/config/initializers/okcomputer.rb
@@ -1,3 +1,14 @@
 # frozen_string_literal: true
 
 OkComputer.mount_at = false
+
+# OKComputer check that checks if we have a connection to symws
+class SymphonyClientCheck < OkComputer::Check
+  def check
+    ping = SymphonyClient.new.ping
+
+    mark_failure unless ping
+  end
+end
+
+OkComputer::Registry.register 'symphony_web_services', SymphonyClientCheck.new

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,1 +1,5 @@
 GOOGLE_ANALYTICS_ID:
+symws:
+  url:
+  headers: {}
+  login_params: {}

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -1,0 +1,6 @@
+symws:
+  url: https://example.com/symws
+  headers: {}
+  login_params:
+    login: 'fake_user'
+    password: 'some_password'

--- a/spec/services/symphony_client_spec.rb
+++ b/spec/services/symphony_client_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe SymphonyClient do
+  let(:client) { subject }
+
+  before do
+    stub_request(:post, 'https://example.com/symws/user/staff/login')
+      .with(body: Settings.symws.login_params.to_h)
+      .to_return(body: { sessionToken: 'tokentokentoken' }.to_json)
+  end
+
+  describe '#ping' do
+    it 'returns true if we can connect to symws' do
+      expect(client.ping).to eq true
+    end
+
+    context 'when unable to connect' do
+      before do
+        stub_request(:post, 'https://example.com/symws/user/staff/login').to_timeout
+      end
+
+      it 'returns false' do
+        expect(client.ping).to eq false
+      end
+    end
+  end
+
+  describe '#session_token' do
+    it 'retrieves a session token from symws' do
+      expect(client.session_token).to eq 'tokentokentoken'
+    end
+  end
+end


### PR DESCRIPTION
Fixes #13 

This is a very simple wrapper around the `HTTP` gem for connecting to symws. It uses data from `Settings` to make requests to the endpoint, and I've added a first action for requesting a session token and then reuse that session token to make additional requests. 

This pairs with https://github.com/sul-dlss/shared_configs/pull/972, which can also be used locally (as `config/settings/development.local.yml`) to test things out.