### PR TITLE
Adds in nav pills fixes #15

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,7 @@
 # frozen_string_literal: true
 
 module ApplicationHelper
+  def active_page_class(name)
+    'active' if controller_name == name
+  end
 end

--- a/app/views/shared/_navigation.html.erb
+++ b/app/views/shared/_navigation.html.erb
@@ -1,6 +1,16 @@
 <nav>
-  <%= link_to 'Summary', root_path %> |
-  <%= link_to 'Checkouts', checkouts_path %> |
-  <%= link_to 'Requests', requests_path %> |
-  <%= link_to 'Fines', fines_path %>
+  <ul class="nav nav-pills nav-justified">
+    <li class="nav-item">
+      <%= link_to 'Summary', root_path, class: "nav-link #{active_page_class('summaries')}" %>
+    </li>
+    <li class="nav-item">
+      <%= link_to 'Checkouts', checkouts_path, class: "nav-link #{active_page_class('checkouts')}" %>
+    </li>
+    <li class="nav-item">
+      <%= link_to 'Requests', requests_path, class: "nav-link #{active_page_class('requests')}" %>
+    </li>
+    <li class="nav-item">
+      <%= link_to 'Fines', fines_path, class: "nav-link #{active_page_class('fines')}" %>
+    </li>
+  </ul>
 </nav>

--- a/spec/features/navigation_spec.rb
+++ b/spec/features/navigation_spec.rb
@@ -51,4 +51,10 @@ RSpec.describe 'Navigation', type: :feature do
 
     expect(page).to have_css('h1', text: 'Summary')
   end
+
+  it 'has an active class for the active page' do
+    visit fines_path
+
+    expect(page).to have_css('.nav-link.active', text: 'Fines')
+  end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ApplicationHelper do
+  describe '#active_page_class' do
+    it 'when the controller_name matches the provided name' do
+      allow(helper).to receive(:controller_name).and_return 'summaries'
+      expect(helper.active_page_class('summaries')).to eq 'active'
+    end
+    it 'when the controller_name does not match' do
+      expect(helper.active_page_class('summaries')).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
This follows the accessibility patterns described here: https://getbootstrap.com/docs/4.3/components/navs/#regarding-accessibility

The nav elements are tabbable <kbd>Tab</kbd> links that can be followed using <kbd>Enter</kbd>

![Screen Shot 2019-07-09 at 9 09 06 AM](https://user-images.githubusercontent.com/1656824/60900650-c4c34080-a229-11e9-90e1-59674db053ac.png)
