### PR TITLE
Perform user authentication and retrieve patron keys from symws

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -26,3 +26,6 @@ RSpec/ExampleLength:
 RSpec/MultipleExpectations:
   Exclude:
     - 'spec/features/**/*'
+
+Layout/IndentFirstHashElement:
+  EnforcedStyle: consistent

--- a/Gemfile
+++ b/Gemfile
@@ -53,15 +53,15 @@ group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: %i[mri mingw x64_mingw]
   gem 'capybara'
-  gem 'rspec-rails'
   gem 'rails-controller-testing'
-  gem 'warden-rspec-rails'
+  gem 'rspec-rails'
   gem 'rubocop'
   gem 'rubocop-performance'
   gem 'rubocop-rails'
   gem 'rubocop-rspec'
   gem 'scss_lint', require: false
   gem 'simplecov', require: false
+  gem 'warden-rspec-rails'
   gem 'webdrivers'
   gem 'webmock'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,8 @@ gem 'jquery-rails'
 
 gem 'bootstrap', '~> 4.3'
 
+gem 'warden'
+
 group :production do
   gem 'mysql2', '~> 0.5'
   gem 'newrelic_rpm'

--- a/Gemfile
+++ b/Gemfile
@@ -54,6 +54,8 @@ group :development, :test do
   gem 'byebug', platforms: %i[mri mingw x64_mingw]
   gem 'capybara'
   gem 'rspec-rails'
+  gem 'rails-controller-testing'
+  gem 'warden-rspec-rails'
   gem 'rubocop'
   gem 'rubocop-performance'
   gem 'rubocop-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -213,6 +213,10 @@ GEM
       bundler (>= 1.3.0)
       railties (= 5.2.3)
       sprockets-rails (>= 2.0.0)
+    rails-controller-testing (1.0.4)
+      actionpack (>= 5.0.1.x)
+      actionview (>= 5.0.1.x)
+      activesupport (>= 5.0.1.x)
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
@@ -327,6 +331,7 @@ GEM
     unicode-display_width (1.6.0)
     warden (1.2.8)
       rack (>= 2.0.6)
+    warden-rspec-rails (0.2.0)
     web-console (3.7.0)
       actionview (>= 5.0)
       activemodel (>= 5.0)
@@ -369,6 +374,7 @@ DEPENDENCIES
   okcomputer
   puma (~> 3.11)
   rails (~> 5.2.3)
+  rails-controller-testing
   rspec-rails
   rubocop
   rubocop-performance
@@ -384,6 +390,7 @@ DEPENDENCIES
   tzinfo-data
   uglifier (>= 1.3.0)
   warden
+  warden-rspec-rails
   web-console (>= 3.3.0)
   webdrivers
   webmock

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -325,6 +325,8 @@ GEM
       unf_ext
     unf_ext (0.0.7.6)
     unicode-display_width (1.6.0)
+    warden (1.2.8)
+      rack (>= 2.0.6)
     web-console (3.7.0)
       actionview (>= 5.0)
       activemodel (>= 5.0)
@@ -381,6 +383,7 @@ DEPENDENCIES
   turbolinks (~> 5)
   tzinfo-data
   uglifier (>= 1.3.0)
+  warden
   web-console (>= 3.3.0)
   webdrivers
   webmock

--- a/app/assets/stylesheets/modules/top_navbar.scss
+++ b/app/assets/stylesheets/modules/top_navbar.scss
@@ -1,27 +1,45 @@
-// scss-lint:disable IdSelector
-
-#topnav-container {
-  padding: 2px 0;
-  position: relative;
-}
+// scss-lint:disable IdSelector, ImportantRule, Indentation, PropertySortOrder
 
 #topnav {
-  background: none;
-  border: 0;
-  height: 29px;
-  margin-bottom: 0;
   padding: 2px 0;
-
-  a {
-    img {
-      float: left;
-    }
-  }
+  height: 29px;
 }
 
-.topnav-links {
-  float: right;
-  margin-top: 2px;
+// these rules are pulled from https://github.com/twbs/bootstrap/blob/master/scss/_navbar.scss
+// but adapted to always show the uncollapsed version, regardless of breakpoints.
+.navbar-expand-always {
+  flex-flow: row nowrap;
+  justify-content: flex-start;
+
+ .navbar-nav {
+   flex-direction: row;
+
+   .dropdown-menu {
+     position: absolute;
+   }
+
+   .nav-link {
+     padding-right: $navbar-nav-link-padding-x;
+     padding-left: $navbar-nav-link-padding-x;
+   }
+ }
+
+ // For nesting containers, have to redeclare for alignment purposes
+ > .container,
+ > .container-fluid {
+   flex-wrap: nowrap;
+ }
+
+ .navbar-collapse {
+   display: flex !important; // stylelint-disable-line declaration-no-important
+
+   // Changes flex-bases to auto because of an IE10 bug
+   flex-basis: auto;
+ }
+
+ .navbar-toggler {
+   display: none;
+ }
 }
 
 @include media-breakpoint-up(xs) {

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,20 @@
 # frozen_string_literal: true
 
+# :nodoc:
 class ApplicationController < ActionController::Base
+  helper_method :current_user
+
+  def current_user
+    request.env['warden'].user
+  end
+
+  def current_user?
+    current_user.present?
+  end
+
+  private
+
+  def authenticate_user!
+    redirect_to root_url unless current_user?
+  end
 end

--- a/app/controllers/checkouts_controller.rb
+++ b/app/controllers/checkouts_controller.rb
@@ -2,5 +2,7 @@
 
 # Controller for the Checkouts page
 class CheckoutsController < ApplicationController
+  before_action :authenticate_user!
+
   def index; end
 end

--- a/app/controllers/fines_controller.rb
+++ b/app/controllers/fines_controller.rb
@@ -2,5 +2,7 @@
 
 # Controller for the Fines and Fees page
 class FinesController < ApplicationController
+  before_action :authenticate_user!
+
   def index; end
 end

--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -2,5 +2,7 @@
 
 # Controller for the requests page
 class RequestsController < ApplicationController
+  before_action :authenticate_user!
+
   def index; end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -5,4 +5,27 @@ class SessionsController < ApplicationController
   def index
     redirect_to summaries_url if current_user?
   end
+
+  def form; end
+
+  def login_by_library_id
+    if request.env['warden'].authenticate(:library_id)
+      redirect_to summaries_url
+    else
+      redirect_to login_url, alert: 'Unable to authenticate.'
+    end
+  end
+
+  def login_by_sunetid
+    if request.env['warden'].authenticate(:shibboleth, :development_shibboleth_stub)
+      redirect_to summaries_url
+    else
+      redirect_to root_url, alert: 'Unable to authenticate.'
+    end
+  end
+
+  def destroy
+    request.env['warden'].logout
+    redirect_to root_url
+  end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# :nodoc:
+class SessionsController < ApplicationController
+  def index
+    redirect_to summaries_url if current_user?
+  end
+end

--- a/app/controllers/summaries_controller.rb
+++ b/app/controllers/summaries_controller.rb
@@ -2,6 +2,8 @@
 
 # :nodoc:
 class SummariesController < ApplicationController
+  before_action :authenticate_user!
+
   # GET /summaries
   # GET /summaries.json
   def index; end

--- a/app/services/symphony_client.rb
+++ b/app/services/symphony_client.rb
@@ -26,7 +26,7 @@ class SymphonyClient
   private
 
   def authenticated_request(path, headers: {}, **other)
-    request(path, headers.merge('x-sirs-sessionToken': session_token), **other)
+    request(path, headers: headers.merge('x-sirs-sessionToken': session_token), **other)
   end
 
   def request(path, headers: {}, method: :get, **other)

--- a/app/services/symphony_client.rb
+++ b/app/services/symphony_client.rb
@@ -14,6 +14,24 @@ class SymphonyClient
     false
   end
 
+  def login(library_id, pin)
+    response = authenticated_request('/user/patron/authenticate', method: :post, json: {
+      barcode: library_id,
+      password: pin
+    })
+
+    JSON.parse(response.body)
+  end
+
+  def login_by_sunetid(sunetid)
+    response = authenticated_request('/user/patron/search', params: {
+      q: "webAuthID:#{sunetid}",
+      includeFields: '*'
+    })
+
+    JSON.parse(response.body)['result'].first
+  end
+
   # get a session token by authenticating to symws
   def session_token
     @session_token ||= begin

--- a/app/views/sessions/form.html.erb
+++ b/app/views/sessions/form.html.erb
@@ -1,0 +1,17 @@
+<h1>Proxy and visitor account login</h1>
+<%= form_tag login_by_library_id_url, method: :post do %>
+
+  <div class="form-group">
+    <%= label_tag :library_id, 'Library ID' %>
+    <%= text_field_tag :library_id, nil, class: 'form-control', 'aria-describedby': 'libraryIdHelp' %>
+    <small id="libraryIdHelp" class="form-text text-muted">Last 10 digits above the barcode on your library card</small>
+  </div>
+
+  <div class="form-group">
+    <%= label_tag :pin, 'PIN' %>
+    <%= password_field_tag :pin, nil, class: 'form-control' %>
+  </div>
+
+  <%= submit_tag 'Log in', class: 'btn btn-primary' %>
+  <%= link_to 'Cancel', root_url, class: 'btn btn-text' %>
+<% end %>

--- a/app/views/sessions/index.html.erb
+++ b/app/views/sessions/index.html.erb
@@ -1,0 +1,8 @@
+<h1>Log in to your library account</h1>
+<p>See your checkouts, requests made from SearchWorks, and any fines or fees you owe.</p>
+
+<h2>Stanford students, faculty, staff</h2>
+<%= link_to 'Log in with SUNet ID', login_by_sunetid_url, class: 'btn btn-primary' %>
+
+<h2>Proxy or fee accounts</h2>
+<%= link_to 'Log in PIN', login_url, class: 'btn btn-light' %>

--- a/app/views/shared/_top_navbar.html.erb
+++ b/app/views/shared/_top_navbar.html.erb
@@ -1,22 +1,17 @@
-<div id="topnav-container">
-  <div class='container'>
-    <header id="topnav" class="header-logo" role="banner">
-      <%= link_to 'https://library.stanford.edu' do %>
-        <%= image_tag "sul-logo.svg", class: "su-logo d-none d-sm-block", alt: "Stanford Libraries", height: 25 %>
-        <%= image_tag "sul-logo-stacked.svg", class: "su-logo d-sm-none d-md-none d-lg-none d-xl-none", alt: "Stanford Libraries", height: 25 %>
+<header id="topnav" class="navbar navbar-expand-always container" role="banner">
+  <%= link_to 'https://library.stanford.edu' do %>
+    <%= image_tag "sul-logo.svg", class: "su-logo d-none d-sm-block", alt: "Stanford Libraries", height: 25 %>
+    <%= image_tag "sul-logo-stacked.svg", class: "su-logo d-sm-none d-md-none d-lg-none d-xl-none", alt: "Stanford Libraries", height: 25 %>
+  <% end %>
+
+  <ul class="navbar-nav ml-auto">
+    <li class="nav-item">
+      <%= link_to feedback_path, data: { toggle: 'collapse', target: '#feedback-form' }, class: 'nav-link' do %>
+        Feedback
       <% end %>
-      <div class='topnav-links'>
-        <ul class='navbar-nav'>
-          <li>
-            <%= link_to feedback_path, data: { toggle: 'collapse', target: '#feedback-form' } do %>
-              Feedback
-            <% end %>
-          </li>
-        </ul>
-      </div>
-    </header>
-  </div>
-</div>
+    </li>
+  </ul>
+</header>
 <div id='feedback-form' class='feedback-form-container collapse'>
   <%= render 'shared/feedback_forms/form' if show_feedback_form? %>
 </div>

--- a/app/views/shared/_top_navbar.html.erb
+++ b/app/views/shared/_top_navbar.html.erb
@@ -6,6 +6,9 @@
 
   <ul class="navbar-nav ml-auto">
     <li class="nav-item">
+      <%= link_to "#{current_user['username']}: logout", logout_url, class: 'nav-link' if current_user %>
+    </li>
+    <li class="nav-item">
       <%= link_to feedback_path, data: { toggle: 'collapse', target: '#feedback-form' }, class: 'nav-link' do %>
         Feedback
       <% end %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -32,6 +32,10 @@ module Mylibrary
     # Don't generate system test files.
     config.generators.system_tests = nil
 
+    config.middleware.use Warden::Manager do |manager|
+      manager.default_strategies :shibboleth
+    end
+
     config.library_map = {
       'ARS' => 'Archive of Recorded Sound',
       'ART' => 'Art & Architecture Library (Bowes)',

--- a/config/initializers/warden.rb
+++ b/config/initializers/warden.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+Warden::Strategies.add(:shibboleth) do
+  def valid?
+    remote_user.present?
+  end
+
+  def authenticate!
+    response = SymphonyClient.new.login_by_sunetid(remote_user)
+
+    if response && response['key']
+      u = { username: remote_user, patronKey: response['key'] }
+      success!(u)
+    else
+      fail!('Could not log in')
+    end
+  end
+
+  private
+
+  def remote_user
+    env['REMOTE_USER']
+  end
+end
+
+Warden::Strategies.add(:development_shibboleth_stub) do
+  def valid?
+    Rails.env.development? && remote_user.present?
+  end
+
+  def authenticate!
+    response = SymphonyClient.new.login_by_sunetid(remote_user)
+
+    if response && response['key']
+      u = { username: remote_user, patronKey: response['key'] }
+      success!(u)
+    else
+      fail!('Could not log in')
+    end
+  end
+
+  private
+
+  def remote_user
+    ENV['REMOTE_USER']
+  end
+end
+
+Warden::Strategies.add(:library_id) do
+  def valid?
+    params['library_id'].present? && params['pin'].present?
+  end
+
+  def authenticate!
+    response = SymphonyClient.new.login(params['library_id'], params['pin'])
+
+    if response['patronKey']
+      u = { username: params['library_id'], name: response['name'], patronKey: response['patronKey'] }
+      success!(u)
+    else
+      fail!('Could not log in')
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,5 +11,10 @@ Rails.application.routes.draw do
   resource :feedback_form, path: 'feedback', only: %I[new create]
   get 'feedback' => 'feedback_forms#new'
 
+  get '/sessions/login_by_sunetid', to: 'sessions#login_by_sunetid', as: :login_by_sunetid
+  post '/sessions/login_by_library_id', to: 'sessions#login_by_library_id', as: :login_by_library_id
+  get '/login', to: 'sessions#form', as: :login
+  get '/logout', to: 'sessions#destroy', as: :logout
+
   mount OkComputer::Engine, at: '/status'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,8 @@
 
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
-  root to: 'summaries#index'
+  root to: 'sessions#index'
+  resources :summaries
   resources :checkouts
   resources :requests
   resources :fines

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ApplicationController do
+  let(:user) do
+    { username: 'somesunetid', patronKey: 123 }
+  end
+
+  describe '#current_user' do
+    before do
+      warden.set_user(user)
+    end
+
+    it 'returns the warden user' do
+      expect(controller.current_user).to eq user
+    end
+  end
+
+  describe '#current_user?' do
+    context 'with a logged in user' do
+      before do
+        warden.set_user(user)
+      end
+
+      it 'is true' do
+        expect(controller.current_user?).to be true
+      end
+    end
+
+    context 'without a logged in user' do
+      it 'is false' do
+        expect(controller.current_user?).to be false
+      end
+    end
+  end
+end

--- a/spec/controllers/checkouts_controller_spec.rb
+++ b/spec/controllers/checkouts_controller_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CheckoutsController do
+  context 'with an unauthenticated request' do
+    it 'redirects to the home page' do
+      expect(get(:index)).to redirect_to root_url
+    end
+  end
+
+  context 'with an authenticated request' do
+    let(:user) do
+      { username: 'somesunetid', patronKey: 123 }
+    end
+
+    before do
+      warden.set_user(user)
+    end
+
+    it 'redirects to the home page' do
+      expect(get(:index)).to render_template 'index'
+    end
+  end
+end

--- a/spec/controllers/fines_controller_spec.rb
+++ b/spec/controllers/fines_controller_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe FinesController do
+  context 'with an unauthenticated request' do
+    it 'redirects to the home page' do
+      expect(get(:index)).to redirect_to root_url
+    end
+  end
+
+  context 'with an authenticated request' do
+    let(:user) do
+      { username: 'somesunetid', patronKey: 123 }
+    end
+
+    before do
+      warden.set_user(user)
+    end
+
+    it 'redirects to the home page' do
+      expect(get(:index)).to render_template 'index'
+    end
+  end
+end

--- a/spec/controllers/requests_controller_spec.rb
+++ b/spec/controllers/requests_controller_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe RequestsController do
+  context 'with an unauthenticated request' do
+    it 'redirects to the home page' do
+      expect(get(:index)).to redirect_to root_url
+    end
+  end
+
+  context 'with an authenticated request' do
+    let(:user) do
+      { username: 'somesunetid', patronKey: 123 }
+    end
+
+    before do
+      warden.set_user(user)
+    end
+
+    it 'redirects to the home page' do
+      expect(get(:index)).to render_template 'index'
+    end
+  end
+end

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe SessionsController do
+  let(:mock_client) { instance_double(SymphonyClient) }
+
+  before do
+    allow(SymphonyClient).to receive(:new).and_return(mock_client)
+  end
+
+  context 'with an authenticated request' do
+    let(:user) do
+      { username: 'somesunetid', patronKey: 123 }
+    end
+
+    before do
+      warden.set_user(user)
+    end
+
+    describe 'GET index' do
+      it 'redirects to the home page' do
+        expect(get(:index)).to redirect_to summaries_url
+      end
+    end
+
+    describe 'GET destroy' do
+      it 'logs out of the current session' do
+        get :destroy
+
+        expect(warden.user).to be_nil
+      end
+
+      it 'redirects to the root' do
+        expect(get(:destroy)).to redirect_to root_url
+      end
+    end
+  end
+
+  describe 'GET index' do
+    it 'renders the index template' do
+      expect(get(:index)).to render_template 'index'
+    end
+  end
+
+  describe 'GET form' do
+    it 'renders the form template' do
+      expect(get(:form)).to render_template 'form'
+    end
+  end
+
+  describe 'POST login_by_library_id' do
+    context 'with a valid login' do
+      before do
+        allow(mock_client).to receive(:login).with('abc', '123').and_return('patronKey' => 1)
+      end
+
+      it 'logs in the user' do
+        post(:login_by_library_id, params: { library_id: 'abc', pin: '123' })
+
+        expect(warden.user).to include username: 'abc', patronKey: 1
+      end
+
+      it 'redirects the user to the summary page' do
+        expect(post(:login_by_library_id, params: { library_id: 'abc', pin: '123' })).to redirect_to summaries_url
+      end
+    end
+
+    context 'with an invalid login' do
+      it 'redirects failed requests back to the login page' do
+        expect(post(:login_by_library_id)).to redirect_to login_url
+      end
+    end
+  end
+
+  describe 'GET login_by_sunetid' do
+    context 'with a valid login' do
+      before do
+        request.env['REMOTE_USER'] = 'test123'
+        allow(mock_client).to receive(:login_by_sunetid).with('test123').and_return('key' => 1)
+      end
+
+      it 'logs in the user' do
+        get(:login_by_sunetid)
+
+        expect(warden.user).to include username: 'test123', patronKey: 1
+      end
+
+      it 'redirects the user to the summary page' do
+        expect(get(:login_by_sunetid)).to redirect_to summaries_url
+      end
+    end
+
+    context 'with an invalid login' do
+      it 'redirects failed requests back to the login page' do
+        expect(get(:login_by_sunetid)).to redirect_to root_url
+      end
+    end
+  end
+end

--- a/spec/controllers/summaries_controller_spec.rb
+++ b/spec/controllers/summaries_controller_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe SummariesController do
+  context 'with an unauthenticated request' do
+    it 'redirects to the home page' do
+      expect(get(:index)).to redirect_to root_url
+    end
+  end
+
+  context 'with an authenticated request' do
+    let(:user) do
+      { username: 'somesunetid', patronKey: 123 }
+    end
+
+    before do
+      warden.set_user(user)
+    end
+
+    it 'redirects to the home page' do
+      expect(get(:index)).to render_template 'index'
+    end
+  end
+end

--- a/spec/features/navigation_spec.rb
+++ b/spec/features/navigation_spec.rb
@@ -3,6 +3,10 @@
 require 'rails_helper'
 
 RSpec.describe 'Navigation', type: :feature do
+  before do
+    login_as 'stub_user'
+  end
+
   it 'the root path navigates to the Summary page' do
     visit root_path
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -67,4 +67,10 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+  config.include Warden::Test::Helpers
+  config.include Warden::Test::ControllerHelpers, type: :controller
+
+  config.after do
+    Warden.test_reset!
+  end
 end

--- a/spec/services/symphony_client_spec.rb
+++ b/spec/services/symphony_client_spec.rb
@@ -32,4 +32,27 @@ RSpec.describe SymphonyClient do
       expect(client.session_token).to eq 'tokentokentoken'
     end
   end
+
+  describe '#login' do
+    before do
+      stub_request(:post, 'https://example.com/symws/user/patron/authenticate')
+        .with(body: { barcode: '123', password: '321' })
+        .to_return(body: { patronKey: 'key' }.to_json)
+    end
+
+    it 'authenticates the user against symphony' do
+      expect(client.login('123', '321')).to include 'patronKey' => 'key'
+    end
+  end
+
+  describe '#login_by_sunetid' do
+    before do
+      stub_request(:get, 'https://example.com/symws/user/patron/search?includeFields=*&q=webAuthID:sunetid')
+        .to_return(body: { result: [{ key: 'key' }] }.to_json)
+    end
+
+    it 'authenticates the user against symphony' do
+      expect(client.login_by_sunetid('sunetid')).to include 'key' => 'key'
+    end
+  end
 end


### PR DESCRIPTION
Fixes #12 

This PR adds authentication workflows for sunetid + libraryid based login (and an extra stub auth strategy for mocking sunetid logins in development). 

Sunetid logins will go through shibboleth, get authenticated by the webserver, and then the result will come back to the application "magically". We then take the resulting user and look up their patron key in symphony.

Library ID logins get authenticated directly against the symphony user authentication API.

In development, you can run the rails server with the `REMOTE_USER` environment variable:

```
REMOTE_USER={your sunetid} be rails s
```

In all cases, we'll stash some enough user data in the current session using Warden so we can do authorization checks, and make additional requests to the symphony API.

Possible follow on work:
- [ ] styling the thing better
- [ ] forgot/reset PIN workflow (#23)