### PR TITLE
Add responsive layout (at least mobile version) to checkouts tab

### DIFF
--- a/app/assets/stylesheets/modules/record.scss
+++ b/app/assets/stylesheets/modules/record.scss
@@ -2,3 +2,18 @@
   @include h3-index-title-font;
   @include h3-index-title-small-font;
 }
+
+
+.expand-icon {
+  display: none;
+}
+
+.collapsed {
+  .collapse-icon {
+    display: none;
+  }
+
+  .expand-icon {
+    display: inline;
+  }
+}

--- a/app/views/checkouts/index.html.erb
+++ b/app/views/checkouts/index.html.erb
@@ -1,20 +1,53 @@
-<p id="notice"><%= notice %></p>
+<p id=""><%= notice %></p>
 
 <h1>Checkouts</h1>
 
 <%= render 'shared/navigation' %>
 
-<% @checkouts.each do |checkout| %>
-  <div class="row">
-    <%= checkout.status %>
-    <%= checkout.overdue? %>
-    <%= checkout.due_date %>
-    <%= checkout.title %>
-    <%= checkout.author %>
-    <%= checkout.call_number %>
-    <%= checkout.checkout_date %>
-    <%= checkout.library %>
-    <%= checkout.recalled_date %>
-    <%= checkout.renewal_date %>
-  </div>
-<% end %>
+<ul>
+  <li class="d-none d-md-inline font-weight-bold">Status</li>
+  <li class="d-none d-md-inline font-weight-bold">Date</li>
+  <li class="d-none d-md-inline font-weight-bold">Title</li>
+  <li class="d-none d-md-inline font-weight-bold">Author name</li>
+  <li class="d-none d-md-inline font-weight-bold">Call number</li>
+</ul>
+
+<ul class="checkouts list-group">
+  <% @checkouts.each_with_index do |checkout, index| %>
+    <li class="d-flex flex-wrap d-md-block list-group-item">
+      <div class="d-flex flex-row flex-grow-1 justify-content-between w-100 d-md-inline">
+        <div class="d-md-inline"><%= checkout.status %></div>
+        <div class="d-md-inline"><%= l(checkout.due_date, format: :short) %></div>
+      </div>
+      <div class="d-flex flex-grow-1 flex-column d-md-inline w-75">
+        <div class="d-md-inline title"><%= checkout.title %></div>
+        <div class="d-flex flex-row d-md-inline">
+          <div class="w-50 d-md-inline"><%= checkout.author %></div>
+          <div class="w-50 d-md-inline call_number"><%= checkout.call_number %></div>
+        </div>
+      </div>
+      <div class="d-md-inline">
+        <button class="d-md-inline btn collapsed" type="button" data-toggle="collapse" data-target="#collapseExample-<%= index %>" aria-expanded="false" aria-controls="collapseExample-<%= index %>">
+          <span class="expand-icon">➕</span>
+          <span class="collapse-icon">➖</span>
+        </button>
+      </div>
+      <div class="collapse w-100" id="collapseExample-<%= index %>">
+        <dl class="row justify-content-center">
+          <dt class="col-5">Borrowed on:</dt>
+          <dd class="col-5"><%= l(checkout.checkout_date, format: :short) %></dd>
+          <% if checkout.renewal_date  %>
+            <dt class="col-5">Renewed on:</dt>
+            <dd class="col-5"><%= l(checkout.renewal_date, format: :short) %></dd>
+          <% end %>
+          <% if checkout.recalled_date  %>
+            <dt class="col-5">Recalled on:</dt>
+            <dd class="col-5"><%= l(checkout.recalled_date, format: :short) %></dd>
+          <% end %>
+          <dt class="col-5">Source:</dt>
+          <dd class="col-5"><%= Mylibrary::Application.config.library_map[checkout.library] || checkout.library %></dd>
+        </dl>
+      </div>
+    </li>
+  <% end %>
+</ul>

--- a/spec/features/checkouts_spec.rb
+++ b/spec/features/checkouts_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Checkout Page', type: :feature do
+  before do
+    login_as(username: 'SUPER1', patron_key: '521181')
+  end
+
+  it 'we see checkout data' do
+    visit checkouts_path
+
+    expect(page).to have_css('ul.checkouts', count: 1)
+    expect(page).to have_css('ul.checkouts li', count: 13)
+
+    within(first('ul.checkouts li')) do
+      expect(page).to have_css('.title', text: /Law and justice in Japanese popular culture/)
+      expect(page).to have_css('.call_number', text: 'P96 .J852 J353 2018')
+    end
+  end
+
+  it 'some data is hidden behind a toggle', js: true do
+    visit checkouts_path
+
+    within(first('ul.checkouts li')) do
+      expect(page).not_to have_css('dl', visible: true)
+      expect(page).not_to have_css('dt', text: 'Borrowed on:', visible: true)
+      click_button '➕'
+      expect(page).to have_css('dl', visible: true)
+      expect(page).to have_css('dt', text: 'Borrowed on:', visible: true)
+    end
+  end
+
+  it 'translates the library code from the response into a name' do
+    visit checkouts_path
+
+    within(first('ul.checkouts li')) do
+      expect(page).to have_css('dl dd', text: 'Law Library (Crown)', visible: false)
+    end
+  end
+end


### PR DESCRIPTION
#16 

![flex-magic](https://user-images.githubusercontent.com/5402927/61057241-b6039780-a3a9-11e9-821f-eea9af35513b.gif)

![CheckoutsToggles](https://user-images.githubusercontent.com/96776/61089793-208bf600-a3f1-11e9-8255-c9801891f991.gif)


- [x] add a `div` for hide / collapse of additional information
- [x] erb-ify, remove dummy data and use Symphony data from #61