### PR TITLE
Enable the default Rails CSP

### DIFF
--- a/app/views/shared/feedback_forms/_form.html.erb
+++ b/app/views/shared/feedback_forms/_form.html.erb
@@ -8,7 +8,7 @@
       </div>
     </div>
     <div class="row">
-      <span style="display:none;visibility:hidden;">
+      <span class="d-none">
         <%= label_tag(:email_address, 'Ignore this text box. It is used to detect spammers. If you enter anything into this text box, your message will not be sent.') %><br/>
         <%= email_field_tag :email_address %><br/>
         <%= hidden_field_tag :user_agent %>

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -6,20 +6,20 @@
 # For further information see the following documentation
 # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy
 
-# Rails.application.config.content_security_policy do |policy|
-#   policy.default_src :self, :https
-#   policy.font_src    :self, :https, :data
-#   policy.img_src     :self, :https, :data
-#   policy.object_src  :none
-#   policy.script_src  :self, :https
-#   policy.style_src   :self, :https
+Rails.application.config.content_security_policy do |policy|
+  policy.default_src :self, :https
+  policy.font_src    :self, :https, :data
+  policy.img_src     :self, :https, :data
+  policy.object_src  :none
+  policy.script_src  :self, :https
+  policy.style_src   :self, :https
 
-#   # Specify URI for violation reports
-#   # policy.report_uri "/csp-violation-report-endpoint"
-# end
+  # Specify URI for violation reports
+  # policy.report_uri "/csp-violation-report-endpoint"
+end
 
 # If you are using UJS then enable automatic nonce generation
-# Rails.application.config.content_security_policy_nonce_generator = -> request { SecureRandom.base64(16) }
+Rails.application.config.content_security_policy_nonce_generator = ->(_request) { SecureRandom.base64(16) }
 
 # Report CSP violations to a specified URI
 # For further information see the following documentation:


### PR DESCRIPTION
Define an application-wide content security policy, using the defaults provided by Rails. Our application is pretty simple, and the rules are fairly permissive by default, so this seems like a good opportunity to try it out.

For further information see the following documentation:
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy