### PR TITLE
Reorganize application layout; fixes #79

### DIFF
--- a/app/views/checkouts/index.html.erb
+++ b/app/views/checkouts/index.html.erb
@@ -2,7 +2,9 @@
 
 <h1>Checkouts</h1>
 
-<%= render 'shared/navigation' %>
+<% content_for(:navigation) do %>
+  <%= render 'shared/navigation' %>
+<% end %>
 
 <% recalled, other_checkouts = @checkouts.partition(&:recalled?) %>
 <% if recalled.any? %>

--- a/app/views/fines/index.html.erb
+++ b/app/views/fines/index.html.erb
@@ -2,7 +2,9 @@
 
 <h1>Fines</h1>
 
-<%= render 'shared/navigation' %>
+<% content_for(:navigation) do %>
+  <%= render 'shared/navigation' %>
+<% end %>
 
 <h2>Refund policy</h2>
 <p>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -20,7 +20,8 @@
     <div id="su-wrap"> <!-- #su-wrap start -->
       <div id="su-content"> <!-- #su-content start -->
         <%= render '/shared/header' %>
-        <main role="main" class="container mt-3 mb-3">
+        <%= content_for(:navigation) %>
+        <main id="main" role="main" class="container mt-3 mb-3">
           <%= render partial: '/shared/flash_msg', layout: nil %>
           <%= yield %>
         </main>

--- a/app/views/requests/index.html.erb
+++ b/app/views/requests/index.html.erb
@@ -2,7 +2,10 @@
 
 <h1>Requests</h1>
 
-<%= render 'shared/navigation' %>
+<% content_for(:navigation) do %>
+  <%= render 'shared/navigation' %>
+<% end %>
+
 
 <h2>If your request isn't listed</h2>
 <p>Mediated requests are not listed until they have been approved, which is typically a day or two before they are transferred to campus.</p>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,2 +1,4 @@
-<%= render 'shared/top_navbar' %>
-<%= render 'shared/header_navbar' %>
+<header role="banner">
+  <%= render 'shared/top_navbar' %>
+  <%= render 'shared/header_navbar' %>
+</header>

--- a/app/views/shared/_header_navbar.html.erb
+++ b/app/views/shared/_header_navbar.html.erb
@@ -1,4 +1,4 @@
-<nav id="header-navbar" class="navbar navbar-expand-md navbar-dark bg-cardinal-red topbar" role="navigation">
+<div id="header-navbar" class="navbar navbar-expand-md navbar-dark bg-cardinal-red topbar">
   <div class="container">
     <%= link_to 'My Library Account', root_path, class: 'navbar-brand py-3' %>
 
@@ -7,4 +7,4 @@
     </button>
 
   </div>
-</nav>
+</div>

--- a/app/views/shared/_navigation.html.erb
+++ b/app/views/shared/_navigation.html.erb
@@ -1,5 +1,5 @@
-<nav>
-  <ul class="nav nav-pills nav-justified">
+<nav role="navigation" aria-label="Main navigation" id="mainnav">
+  <ul class="nav nav-pills nav-justified container">
     <li class="nav-item">
       <%= link_to 'Summary', root_path, class: "nav-link #{active_page_class('summaries')}" %>
     </li>

--- a/app/views/shared/_top_navbar.html.erb
+++ b/app/views/shared/_top_navbar.html.erb
@@ -1,4 +1,4 @@
-<header id="topnav" class="navbar navbar-expand-always container" role="banner">
+<nav id="topnav" class="navbar navbar-expand-always container" role="banner">
   <%= link_to 'https://library.stanford.edu' do %>
     <%= image_tag "sul-logo.svg", class: "su-logo d-none d-sm-block", alt: "Stanford Libraries", height: 25 %>
     <%= image_tag "sul-logo-stacked.svg", class: "su-logo d-sm-none d-md-none d-lg-none d-xl-none", alt: "Stanford Libraries", height: 25 %>
@@ -14,7 +14,7 @@
       <% end %>
     </li>
   </ul>
-</header>
+</nav>
 <div id='feedback-form' class='feedback-form-container collapse'>
   <%= render 'shared/feedback_forms/form' if show_feedback_form? %>
 </div>

--- a/app/views/summaries/index.html.erb
+++ b/app/views/summaries/index.html.erb
@@ -2,7 +2,10 @@
 
 <h1>Summary</h1>
 
-<%= render 'shared/navigation' %>
+<% content_for(:navigation) do %>
+  <%= render 'shared/navigation' %>
+<% end %>
+
 
 <h2>Policies &amp; information</h2>
 <ul>

--- a/spec/features/navigation_spec.rb
+++ b/spec/features/navigation_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe 'Navigation', type: :feature do
   it 'has navigation with links to the main pages' do
     visit root_path
 
-    within('main nav') do
+    within('#mainnav') do
       expect(page).to have_link('Summary')
       expect(page).to have_link('Checkouts')
       expect(page).to have_link('Requests')


### PR DESCRIPTION
Fixes #79

Before:
<img width="529" alt="Screen Shot 2019-07-11 at 17 28 28" src="https://user-images.githubusercontent.com/111218/61093851-4de0a000-a401-11e9-8be4-a0989b588031.png">

After:
<img width="782" alt="Screen Shot 2019-07-11 at 17 28 05" src="https://user-images.githubusercontent.com/111218/61093837-402b1a80-a401-11e9-9822-653cbffc16b6.png">
