### PR TITLE
Explicitly add turbolinks progress bar styles

### DIFF
--- a/app/assets/stylesheets/base.scss
+++ b/app/assets/stylesheets/base.scss
@@ -53,3 +53,15 @@ thead {
   color: $sul-h2-font-color;
   font-weight: 700;
 }
+
+.turbolinks-progress-bar {
+  background: $blue;
+  display: block;
+  height: 3px;
+  left: 0;
+  position: fixed;
+  top: 0;
+  transform: translate3d(0, 0, 0);
+  transition: width 300ms ease-out, opacity 150ms 150ms ease-in;
+  z-index: 9999;
+}


### PR DESCRIPTION
Turbolinks injects an inline `<style>` element, which doesn't play nice with the content security policies. Supposedly, there may be a way to whitelist it using a hash of its content, but I can't figure out how to make it work cross-browser. For now, we can just add the styles ourselves and ignore their styling entirely.