### PR TITLE
Add a JSON-API-ish representation of checkouts

### DIFF
--- a/app/views/checkouts/_checkout.json.jbuilder
+++ b/app/views/checkouts/_checkout.json.jbuilder
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+json.type 'checkout'
+json.id checkout.key
+json.attributes do
+  json.status checkout.status
+  json.due_date checkout.due_date
+  json.checkout_date checkout.checkout_date
+  json.recalled_date checkout.recalled_date
+  json.recalled? checkout.recalled?
+  json.renewal_date checkout.renewal_date
+  json.overdue? checkout.overdue?
+  json.library checkout.library
+  json.catkey checkout.catkey
+  json.title checkout.title
+  json.author checkout.author
+  json.call_number checkout.call_number
+  json.shelf_key checkout.shelf_key
+
+  json.symphony_api_response checkout.record if Rails.env.development?
+end

--- a/app/views/checkouts/index.json.jbuilder
+++ b/app/views/checkouts/index.json.jbuilder
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+json.links do
+  json.self checkouts_url
+end
+
+json.data do
+  json.array! @checkouts, partial: 'checkouts/checkout', as: :checkout
+end


### PR DESCRIPTION
and include the original symphony response when in development.

If you visit e.g. http://127.0.0.1:3000/checkouts.json, you'll get something like:

<img width="417" alt="Screen Shot 2019-07-12 at 08 30 11" src="https://user-images.githubusercontent.com/111218/61139928-46f87280-a47f-11e9-863e-99cf247fb88e.png">

This might be a useful development tool, if nothing else making it easier to see what's actually in the Symphony API response 🤷‍♂ 