### PR TITLE
Update scaffolded pages to remove unneeded notice area 

### DIFF
--- a/app/views/checkouts/index.html.erb
+++ b/app/views/checkouts/index.html.erb
@@ -1,6 +1,4 @@
-<p id=""><%= notice %></p>
-
-<h1>Checkouts</h1>
+<h1 class="sr-only">Checkouts</h1>
 
 <% content_for(:navigation) do %>
   <%= render 'shared/navigation' %>

--- a/app/views/fines/index.html.erb
+++ b/app/views/fines/index.html.erb
@@ -1,6 +1,4 @@
-<p id="notice"><%= notice %></p>
-
-<h1>Fines</h1>
+<h1 class="sr-only">Fines</h1>
 
 <% content_for(:navigation) do %>
   <%= render 'shared/navigation' %>

--- a/app/views/requests/index.html.erb
+++ b/app/views/requests/index.html.erb
@@ -1,6 +1,4 @@
-<p id="notice"><%= notice %></p>
-
-<h1>Requests</h1>
+<h1 class="sr-only">Requests</h1>
 
 <% content_for(:navigation) do %>
   <%= render 'shared/navigation' %>

--- a/app/views/summaries/index.html.erb
+++ b/app/views/summaries/index.html.erb
@@ -1,6 +1,4 @@
-<p id="notice"><%= notice %></p>
-
-<h1>Summary</h1>
+<h1 class="sr-only">Summary</h1>
 
 <% content_for(:navigation) do %>
   <%= render 'shared/navigation' %>


### PR DESCRIPTION
and also hide generic the `h1` except for screenreaders