### PR TITLE
Update fines page to use flex-box layout/proper headers/etc.

### DIFF
--- a/app/views/fines/_fine.html.erb
+++ b/app/views/fines/_fine.html.erb
@@ -1,11 +1,39 @@
-<li>
-  <%= fine.key %>
-  <%= fine.status %>
-  <%= fine.catkey %>
-  <%= fine.title %>
-  <%= fine.author %>
-  <%= fine.call_number %>
-  <%= fine.shelf_key %>
-  <%= fine.bill_date %>
-  <%= fine.owed %>
+<li class="row d-flex flex-wrap list-group-item">
+  <div class="d-flex flex-row flex-grow-1 justify-content-between w-100 row col-md-4">
+    <div class="w-50 col-md-6 status">
+      <%= fine.status %>
+    </div>
+    <div class="w-50 col-md-6 text-right text-md-left owed">
+      <%= number_to_currency(fine.owed) %>
+    </div>
+  </div>
+  <div class="d-flex flex-grow-1 flex-column flex-md-row w-75 row col-md-8">
+    <h3 class="col-md-7 record-title title"><%= fine.title %></h3>
+    <div class="d-flex flex-row row col-md-5">
+      <div class="w-50 col-md-6 author"><%= fine.author %></div>
+      <div class="w-50 col-md-6 call_number" data-shelfkey="<%= fine.shelf_key %>"><%= fine.call_number %></div>
+    </div>
+  </div>
+  <div>
+    <button class="btn collapsed" type="button" data-toggle="collapse" data-target="#collapseExample-<%= fine.key.parameterize %>" aria-expanded="false" aria-controls="collapseExample-<%= fine.key.parameterize %>">
+      <span class="expand-icon"><%= sul_icon :'sharp-add-24px' %><span class="sr-only">Expand</span></span>
+      <span class="collapse-icon"><%= sul_icon :'sharp-remove-24px' %><span class="sr-only">Collapse</span></span>
+    </button>
+  </div>
+  <div class="collapse w-100" id="collapseExample-<%= fine.key.parameterize %>">
+    <dl class="row justify-content-center">
+      <dt class="col-5">Billed on:</dt>
+      <dd class="col-5"><%= l(fine.bill_date, format: :short) %></dd>
+      <dt class="col-5">Source:</dt>
+      <dd class="col-5"><%= Mylibrary::Application.config.library_map[fine.library] || fine.library %></dd>
+    </dl>
+    <div class="row justify-content-center">
+      <div class="col-5">
+        <%= link_to Settings.sw.url + fine.catkey, target: '_blank' do %>
+          <%= sul_icon :'sharp-open_in_new-24px' %> View in SearchWorks
+        <% end %>
+      </div>
+      <div class="col-5"></div>
+    </div>
+  </div>
 </li>

--- a/app/views/fines/index.html.erb
+++ b/app/views/fines/index.html.erb
@@ -4,11 +4,29 @@
   <%= render 'shared/navigation' %>
 <% end %>
 
-<div class="page-section">
-  <ul class="fines list-group">
-    <%= render @fines %>
-  </ul>
-</div>
+<% if @fines.any? %>
+  <div class="page-section">
+    <h2>Payable <%= number_to_currency(@fines.sum(&:owed)) %></h2>
+
+    <div class="d-none d-md-flex row font-weight-bold list-header">
+      <div class="row col-md-4">
+        <div class="col-md-6">Reason</div>
+        <div class="col-md-6">Amount</div>
+      </div>
+      <div class="row col-md-8">
+        <div class="col-md-7">Title</div>
+        <div class="row col-md-5">
+          <div class="col-md-6">Author</div>
+          <div class="col-md-6 call_number">Call number</div>
+        </div>
+      </div>
+    </div>
+
+    <ul class="fines list-group">
+      <%= render @fines %>
+    </ul>
+  </div>
+<% end %>
 
 <div class="page-section">
   <h2>Refund policy</h2>

--- a/spec/features/fines_spec.rb
+++ b/spec/features/fines_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Fines Page', type: :feature do
+  before do
+    login_as(username: 'SUPER1', patron_key: '521181')
+  end
+
+  it 'totals all the fines into the header' do
+    visit fines_path
+
+    expect(page).to have_css('h2', text: 'Payable $7.00')
+  end
+
+  it 'renders a list item for every fine' do
+    visit fines_path
+
+    within('ul.fines') do
+      expect(page).to have_css('li', count: 1)
+      expect(page).to have_css('li h3', text: 'Research handbook on the law of virtual and augmented reality')
+    end
+  end
+
+  it 'has content behind a toggle', js: true do
+    visit fines_path
+
+    within('ul.fines') do
+      expect(page).not_to have_css('dl', visible: true)
+      expect(page).not_to have_css('dt', text: 'Billed on', visible: true)
+      click_button 'Expand'
+      expect(page).to have_css('dl', visible: true)
+      expect(page).to have_css('dt', text: 'Billed on', visible: true)
+    end
+  end
+end

--- a/spec/support/fixtures/patron/521181.json
+++ b/spec/support/fixtures/patron/521181.json
@@ -41,6 +41,101 @@
         "data": "somebody@stanford.edu"
       }
     }],
+    "blockList": [{
+      "resource": "/circulation/block",
+      "key": "521181:1",
+      "fields": {
+        "patron": {
+          "resource": "/user/patron",
+          "key": "521181"
+        },
+        "createDate": "2019-07-08",
+        "amount": {
+          "currencyCode": "USD",
+          "amount": "7.00"
+        },
+        "owed": {
+          "currencyCode": "USD",
+          "amount": "7.00"
+        },
+        "tax": {
+          "currencyCode": "USD",
+          "amount": "0.00"
+        },
+        "block": {
+          "resource": "/policy/block",
+          "key": "DAMAGED"
+        },
+        "item": {
+          "resource": "/catalog/item",
+          "key": "12871638:1:1",
+          "fields": {
+            "bib": {
+              "resource": "/catalog/bib",
+              "key": "12871638",
+              "fields": {
+                "author": "",
+                "title": "Research handbook on the law of virtual and augmented reality"
+              }
+            },
+            "call": {
+              "resource": "/catalog/call",
+              "key": "12871638:1",
+              "fields": {
+                "dispCallNumber": "K564 .C6 R47 2018",
+                "sortCallNumber": "K  000564 .C6  R47  2018"
+              }
+            },
+            "barcode": "36105228879115",
+            "circulate": false,
+            "copyNumber": 1,
+            "createdDate": "2019-01-25",
+            "currentLocation": {
+              "resource": "/policy/location",
+              "key": "CHECKEDOUT"
+            },
+            "homeLocation": {
+              "resource": "/policy/location",
+              "key": "BASEMENT"
+            },
+            "itemCategory1": null,
+            "itemCategory2": null,
+            "itemCategory3": null,
+            "itemCategory4": null,
+            "itemCategory5": null,
+            "itemType": {
+              "resource": "/policy/itemType",
+              "key": "LAW-STKS"
+            },
+            "lastInvDate": null,
+            "library": {
+              "resource": "/policy/library",
+              "key": "LAW"
+            },
+            "mediaDesk": null,
+            "permanent": true,
+            "pieces": 1,
+            "price": {
+              "currencyCode": "USD",
+              "amount": "0.00"
+            },
+            "shadowed": false,
+            "systemModifiedDate": "2019-07-08T21:53:00-07:00",
+            "timesInventoried": 0
+          }
+        },
+        "comment": null,
+        "library": {
+          "resource": "/policy/library",
+          "key": "GREEN"
+        },
+        "billDate": "2019-07-08",
+        "estimatedOverdueAmount": {
+          "currencyCode": "USD",
+          "amount": "0.00"
+        }
+      }
+    }],
     "circRecordList": [{
         "key": "12735651:1:1:1",
         "fields": {


### PR DESCRIPTION
Part of #86 

This only lists the fines and doesn't get history or deal w/ displaying accruing fines (not sure if this should be spun out into separate tickets or not).

There also may be some data missing (primarily `borrowed on` date and `assumed lost fee`) that didn't seem to be coming back in the response.  Happy to pair on that, or ship this and split that out into a separate ticket as well.

![fines-responsive](https://user-images.githubusercontent.com/96776/61253144-d8344700-a714-11e9-85bb-02ab299e2fae.gif)
