### PR TITLE
Add days remaining until due date

### DIFF
--- a/app/models/checkout.rb
+++ b/app/models/checkout.rb
@@ -40,6 +40,12 @@ class Checkout
     fields['overdue']
   end
 
+  def days_remaining
+    return 0 if overdue?
+
+    (due_date.to_date - Time.zone.now.to_date).to_i
+  end
+
   def library
     fields['library']['key']
   end

--- a/app/views/checkouts/_checkout.html.erb
+++ b/app/views/checkouts/_checkout.html.erb
@@ -36,6 +36,10 @@
         <dt class="col-5">Recalled on:</dt>
         <dd class="col-5"><%= l(checkout.recalled_date, format: :short) %></dd>
       <% end %>
+      <% unless checkout.overdue? %>
+        <dt class="col-5">Remaining:</dt>
+        <dd class="col-5"><%= pluralize(checkout.days_remaining, 'day') %> </dd>
+      <% end %>
       <dt class="col-5">Source:</dt>
       <dd class="col-5"><%= Mylibrary::Application.config.library_map[checkout.library] || checkout.library %></dd>
     </dl>

--- a/spec/models/checkout_spec.rb
+++ b/spec/models/checkout_spec.rb
@@ -52,6 +52,30 @@ RSpec.describe Checkout do
     expect(checkout.overdue?).to be true
   end
 
+  describe '#days_remaining' do
+    context 'when overdue' do
+      before do
+        fields['dueDate'] = '2019-07-10T13:59:00-07:00'
+        fields['overdue'] = true
+      end
+
+      it 'has negative days remaining' do
+        expect(checkout.days_remaining).to eq 0
+      end
+    end
+
+    context 'when overdue' do
+      before do
+        fields['dueDate'] = (Time.zone.now + 5.days).to_s
+        fields['overdue'] = false
+      end
+
+      it 'has a positive number of days remaining' do
+        expect(checkout.days_remaining).to eq 5
+      end
+    end
+  end
+
   it 'has a due date' do
     expect(checkout.due_date.strftime('%m/%d/%Y')).to eq '07/09/2019'
   end


### PR DESCRIPTION
Part of #120 

This PR adds logic to calculate days until an item is due. This is added to checkout details, but hidden if the item is overdue.

## Current item ✅
![not overdue item](https://user-images.githubusercontent.com/5402927/61255701-88f31400-a71e-11e9-9035-1f5ab6557229.png)

## Overdue ⚠️
![overdue item](https://user-images.githubusercontent.com/5402927/61255700-88f31400-a71e-11e9-82e4-ff5fa932a687.png)

