### PR TITLE
Move the modal out of the navbar so it doesn't get the navbar-specific css

### DIFF
--- a/app/views/shared/_header_navbar.html.erb
+++ b/app/views/shared/_header_navbar.html.erb
@@ -6,13 +6,6 @@
         <%= link_to contact_path, class: 'navbar-link', 'data-toggle' =>  'modal', 'data-target' => '#contact-modal-window' do %>
           <%= sul_icon :'sharp-email-24px', classes: 'mr-1' %> Contact Access Services
         <% end %>
-        <div class="modal fade" id="contact-modal-window" tabindex="-1" role="dialog" aria-labelledby="contactForm" aria-hidden="true">
-          <div class="modal-dialog" role="document">
-            <div class="modal-content">
-              <%= render 'shared/contact_forms/form' %>
-            </div>
-          </div>
-        </div>
         <%= link_to 'tel:+16507231493', class: 'navbar-link' do %>
           <%= sul_icon :'sharp-phone-24px', classes: 'mr-1' %> (650) 723-1493
         <% end %>
@@ -20,3 +13,13 @@
     </div>
   </div>
 </div>
+
+<% if current_user? %>
+  <div class="modal fade" id="contact-modal-window" tabindex="-1" role="dialog" aria-labelledby="contactForm" aria-hidden="true">
+    <div class="modal-dialog" role="document">
+      <div class="modal-content">
+        <%= render 'shared/contact_forms/form' %>
+      </div>
+    </div>
+  </div>
+<% end %>


### PR DESCRIPTION
After:

<img width="530" alt="Screen Shot 2019-07-16 at 07 16 51" src="https://user-images.githubusercontent.com/111218/61301890-b4ffab00-a799-11e9-8fac-c742ef4e0191.png">

Fixes #135 