### PR TITLE
Guard against fines without an associated item; fixes #151

### DIFF
--- a/app/models/fine.rb
+++ b/app/models/fine.rb
@@ -17,23 +17,23 @@ class Fine
   end
 
   def catkey
-    fields['item']['fields']['bib']['key']
+    bib && fields['item']['fields']['bib']['key']
   end
 
   def title
-    bib['title']
+    bib && bib['title']
   end
 
   def author
-    bib['author']
+    bib && bib['author']
   end
 
   def call_number
-    call['dispCallNumber']
+    call && call['dispCallNumber']
   end
 
   def shelf_key
-    call['sortCallNumber']
+    call && call['sortCallNumber']
   end
 
   def library
@@ -48,6 +48,10 @@ class Fine
     fields['owed']['amount'].to_d
   end
 
+  def bib?
+    bib.present?
+  end
+
   def to_partial_path
     'fines/fine'
   end
@@ -59,10 +63,10 @@ class Fine
   end
 
   def bib
-    fields['item']['fields']['bib']['fields']
+    fields['item'] && fields['item']['fields']['bib'] && fields['item']['fields']['bib']['fields']
   end
 
   def call
-    fields['item']['fields']['call']['fields']
+    fields['item'] && fields['item']['fields']['call'] && fields['item']['fields']['call']['fields']
   end
 end

--- a/app/views/fines/_fine.html.erb
+++ b/app/views/fines/_fine.html.erb
@@ -8,11 +8,13 @@
     </div>
   </div>
   <div class="d-flex flex-grow-1 flex-column flex-md-row w-75 row col-md-8">
-    <h3 class="col-md-7 record-title title"><%= fine.title %></h3>
-    <div class="d-flex flex-row row col-md-5">
-      <div class="w-50 col-md-6 author"><%= fine.author %></div>
-      <div class="w-50 col-md-6 call_number" data-shelfkey="<%= fine.shelf_key %>"><%= fine.call_number %></div>
-    </div>
+    <% if fine.bib? %>
+      <h3 class="col-md-7 record-title title"><%= fine.title %></h3>
+      <div class="d-flex flex-row row col-md-5">
+        <div class="w-50 col-md-6 author"><%= fine.author %></div>
+        <div class="w-50 col-md-6 call_number" data-shelfkey="<%= fine.shelf_key %>"><%= fine.call_number %></div>
+      </div>
+    <% end %>
   </div>
   <div>
     <button class="btn collapsed" type="button" data-toggle="collapse" data-target="#collapseExample-<%= fine.key.parameterize %>" aria-expanded="false" aria-controls="collapseExample-<%= fine.key.parameterize %>">
@@ -28,6 +30,6 @@
       <dd class="col-5"><%= library_name fine.library %></dd>
     </dl>
 
-    <%= detail_link_to_searchworks(fine.catkey) %>
+    <%= detail_link_to_searchworks(fine.catkey) if fine.bib? %>
   </div>
 </li>

--- a/spec/models/fine_spec.rb
+++ b/spec/models/fine_spec.rb
@@ -74,4 +74,53 @@ RSpec.describe Fine do
   it 'has an amount owed' do
     expect(fine.owed).to eq 5000.00
   end
+
+  context 'without a related item' do
+    let(:fields) do
+      {
+        block: { key: 'DAMAGED' },
+        billDate: '2019-07-11',
+        owed: {
+          amount: '5000.00',
+          currencyCode: 'USD'
+        }
+      }
+    end
+
+    describe '#bib?' do
+      it 'is false' do
+        expect(fine.bib?).to eq false
+      end
+    end
+
+    describe '#title' do
+      it 'is nil' do
+        expect(fine.title).to eq nil
+      end
+    end
+
+    describe '#author' do
+      it 'is nil' do
+        expect(fine.author).to eq nil
+      end
+    end
+
+    describe '#catkey' do
+      it 'is nil' do
+        expect(fine.catkey).to eq nil
+      end
+    end
+
+    describe '#call_number' do
+      it 'is nil' do
+        expect(fine.call_number).to eq nil
+      end
+    end
+
+    describe '#shelf_key' do
+      it 'is nil' do
+        expect(fine.shelf_key).to eq nil
+      end
+    end
+  end
 end


### PR DESCRIPTION
It looks like @jgreben ran into an exception in -dev because of a fine without an associated item. I'm not sure if this is a real use case or just some bad test data, but guarding against it is easy enough, so 🤷‍♂ 