### PR TITLE
Make short term loan's due date show the time instead of just date

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -5,14 +5,6 @@ module ApplicationHelper
     'active' if controller_name == name
   end
 
-  def list_group_item_status_for_checkout(checkout)
-    if checkout.recalled?
-      'list-group-item-danger'
-    elsif checkout.overdue?
-      'list-group-item-warning'
-    end
-  end
-
   # Wrap a link to the SearchWorks record for the given Catkey wrapped in the markup
   # necessary to be aligned with the content in the collapsible list sections
   def detail_link_to_searchworks(catkey)

--- a/app/helpers/checkouts_helper.rb
+++ b/app/helpers/checkouts_helper.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# Helper for checkouts views
+module CheckoutsHelper
+  def today_with_time_or_date(date, short_term: false)
+    return l(date, format: :short) unless short_term
+    return l(date, format: :short) unless date.today?
+
+    l(date, format: :time_today)
+  end
+
+  def time_remaining_for_checkout(checkout)
+    return pluralize(checkout.days_remaining, 'day') unless checkout.short_term_loan?
+
+    distance_of_time_in_words(Time.zone.now, checkout.due_date)
+  end
+end

--- a/app/helpers/checkouts_helper.rb
+++ b/app/helpers/checkouts_helper.rb
@@ -2,6 +2,14 @@
 
 # Helper for checkouts views
 module CheckoutsHelper
+  def list_group_item_status_for_checkout(checkout)
+    if checkout.recalled?
+      'list-group-item-danger'
+    elsif checkout.overdue?
+      'list-group-item-warning'
+    end
+  end
+
   def today_with_time_or_date(date, short_term: false)
     return l(date, format: :short) unless short_term
     return l(date, format: :short) unless date.today?

--- a/app/models/checkout.rb
+++ b/app/models/checkout.rb
@@ -4,6 +4,8 @@
 class Checkout
   attr_reader :record
 
+  SHORT_TERM_LOAN_PERIODS = %w[HOURLY].freeze
+
   def initialize(record)
     @record = record
   end
@@ -74,6 +76,10 @@ class Checkout
     call['sortCallNumber']
   end
 
+  def short_term_loan?
+    SHORT_TERM_LOAN_PERIODS.include?(loan_period_type)
+  end
+
   def to_partial_path
     'checkouts/checkout'
   end
@@ -82,6 +88,10 @@ class Checkout
 
   def fields
     record['fields']
+  end
+
+  def loan_period_type
+    fields.dig('circulationRule', 'fields', 'loanPeriod', 'fields', 'periodType', 'key')
   end
 
   def bib

--- a/app/services/symphony_client.rb
+++ b/app/services/symphony_client.rb
@@ -41,6 +41,8 @@ class SymphonyClient
     end
   end
 
+  # Symphony API requires some loooong strings, disabling LineLength for this method
+  # rubocop:disable Metrics/LineLength
   def patron_info(patron_key)
     response = authenticated_request("/user/patron/key/#{patron_key}", params: {
       includeFields: [
@@ -49,13 +51,14 @@ class SymphonyClient
         'profile{chargeLimit}',
         'groupSettings{responsibility}',
         'holdRecordList{*,item{*,bib{title,author},call{sortCallNumber,dispCallNumber}}}',
-        'circRecordList{*,item{*,bib{title,author},call{sortCallNumber,dispCallNumber}}}',
+        'circRecordList{*,circulationRule{loanPeriod{periodType{key}}},item{*,bib{title,author},call{sortCallNumber,dispCallNumber}}}',
         'blockList{*,item{*,bib{title,author},call{sortCallNumber,dispCallNumber}}}'
       ].join(',')
     })
 
     JSON.parse(response.body)
   end
+  # rubocop:enable Metrics/LineLength
 
   def reset_pin(library_id, reset_path)
     response = request('/user/patron/resetMyPin', method: :post, json: {

--- a/app/views/checkouts/_checkout.html.erb
+++ b/app/views/checkouts/_checkout.html.erb
@@ -26,7 +26,7 @@
   </div>
   <div class="collapse w-100" id="collapseExample-<%= checkout.key.parameterize %>">
     <dl class="row justify-content-center">
-      <dt class="col-5">Borrowed on:</dt>
+      <dt class="col-5">Borrowed:</dt>
       <dd class="col-5">
         <%= today_with_time_or_date(checkout.checkout_date, short_term: checkout.short_term_loan?) %>
       </dd>

--- a/app/views/checkouts/_checkout.html.erb
+++ b/app/views/checkouts/_checkout.html.erb
@@ -8,7 +8,7 @@
       <% end %>
     </div>
     <div class="w-50 col-md-6 text-right text-md-left due_date" data-date="<%= checkout.due_date.strftime('%FT%T') %>">
-      <%= l(checkout.due_date, format: :short) %>
+      <%= today_with_time_or_date(checkout.due_date, short_term: checkout.short_term_loan?) %>
     </div>
   </div>
   <div class="d-flex flex-grow-1 flex-column flex-md-row w-75 row col-md-8">
@@ -27,7 +27,9 @@
   <div class="collapse w-100" id="collapseExample-<%= checkout.key.parameterize %>">
     <dl class="row justify-content-center">
       <dt class="col-5">Borrowed on:</dt>
-      <dd class="col-5"><%= l(checkout.checkout_date, format: :short) %></dd>
+      <dd class="col-5">
+        <%= today_with_time_or_date(checkout.checkout_date, short_term: checkout.short_term_loan?) %>
+      </dd>
       <% if checkout.renewal_date  %>
         <dt class="col-5">Renewed on:</dt>
         <dd class="col-5"><%= l(checkout.renewal_date, format: :short) %></dd>
@@ -38,7 +40,7 @@
       <% end %>
       <% unless checkout.overdue? %>
         <dt class="col-5">Remaining:</dt>
-        <dd class="col-5"><%= pluralize(checkout.days_remaining, 'day') %> </dd>
+        <dd class="col-5"><%= time_remaining_for_checkout(checkout) %></dd>
       <% else %>
         <dt class="col-5">Fines accrued:</dt>
         <dd class="col-5"><%= number_to_currency(checkout.accrued) %> </dd>

--- a/app/views/checkouts/index.html.erb
+++ b/app/views/checkouts/index.html.erb
@@ -11,7 +11,7 @@
     <div class="d-none d-md-flex row font-weight-bold list-header">
       <div class="row col-md-4">
         <div class="col-md-6">Status</div>
-        <div class="col-md-6">Date</div>
+        <div class="col-md-6">Due date</div>
       </div>
       <div class="row col-md-8">
         <div class="col-md-7">Title</div>
@@ -48,7 +48,7 @@
   <div class="d-none d-md-flex row font-weight-bold list-header">
     <div class="row col-md-4">
       <div class="col-md-6" data-sort="status">Status</div>
-      <div class="col-md-6 active" data-sort="due_date">Date</div>
+      <div class="col-md-6 active" data-sort="due_date">Due date</div>
     </div>
     <div class="row col-md-8">
       <div class="col-md-7" data-sort="title">Title</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -34,6 +34,7 @@ en:
     formats:
       short: '%B %e, %Y'
       long: '%B %e, %Y %l:%M%P'
+      time_today: 'Today at %l:%M%P'
   hello: "Hello world"
   mylibrary:
     change_pin:

--- a/spec/features/checkouts_spec.rb
+++ b/spec/features/checkouts_spec.rb
@@ -38,10 +38,10 @@ RSpec.describe 'Checkout Page', type: :feature do
 
     within(first('ul.checkouts li')) do
       expect(page).not_to have_css('dl', visible: true)
-      expect(page).not_to have_css('dt', text: 'Borrowed on:', visible: true)
+      expect(page).not_to have_css('dt', text: 'Borrowed:', visible: true)
       click_button 'Expand'
       expect(page).to have_css('dl', visible: true)
-      expect(page).to have_css('dt', text: 'Borrowed on:', visible: true)
+      expect(page).to have_css('dt', text: 'Borrowed:', visible: true)
       expect(page).to have_css('dt', text: 'Fines accrued:', visible: true)
       expect(page).to have_css('dd', text: '$0.00', visible: true)
     end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -13,24 +13,6 @@ RSpec.describe ApplicationHelper do
     end
   end
 
-  describe '#list_group_item_status_for_checkout' do
-    context 'with a recalled item' do
-      let(:checkout) { instance_double(Checkout, recalled?: true) }
-
-      it 'is *-danger' do
-        expect(helper.list_group_item_status_for_checkout(checkout)).to eq 'list-group-item-danger'
-      end
-    end
-
-    context 'with an overdue item' do
-      let(:checkout) { instance_double(Checkout, recalled?: false, overdue?: true) }
-
-      it 'is *-warning' do
-        expect(helper.list_group_item_status_for_checkout(checkout)).to eq 'list-group-item-warning'
-      end
-    end
-  end
-
   describe '#detail_link_to_searchworks' do
     let(:content) { Capybara.string(helper.detail_link_to_searchworks('12345')) }
 

--- a/spec/helpers/checkouts_helper_spec.rb
+++ b/spec/helpers/checkouts_helper_spec.rb
@@ -3,6 +3,24 @@
 require 'rails_helper'
 
 RSpec.describe CheckoutsHelper do
+  describe '#list_group_item_status_for_checkout' do
+    context 'with a recalled item' do
+      let(:checkout) { instance_double(Checkout, recalled?: true) }
+
+      it 'is *-danger' do
+        expect(helper.list_group_item_status_for_checkout(checkout)).to eq 'list-group-item-danger'
+      end
+    end
+
+    context 'with an overdue item' do
+      let(:checkout) { instance_double(Checkout, recalled?: false, overdue?: true) }
+
+      it 'is *-warning' do
+        expect(helper.list_group_item_status_for_checkout(checkout)).to eq 'list-group-item-warning'
+      end
+    end
+  end
+
   describe '#time_remaining_for_checkout' do
     context 'when the checkout is a short term loan' do
       let(:checkout) { instance_double(Checkout, short_term_loan?: true, due_date: Time.zone.now + 42.minutes) }

--- a/spec/helpers/checkouts_helper_spec.rb
+++ b/spec/helpers/checkouts_helper_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CheckoutsHelper do
+  describe '#time_remaining_for_checkout' do
+    context 'when the checkout is a short term loan' do
+      let(:checkout) { instance_double(Checkout, short_term_loan?: true, due_date: Time.zone.now + 42.minutes) }
+
+      it 'returns the distance of time in words' do
+        expect(helper.time_remaining_for_checkout(checkout)).to eq '42 minutes'
+      end
+    end
+
+    context 'when the checkout is not a short term loan' do
+      let(:checkout) { instance_double(Checkout, short_term_loan?: false, days_remaining: 42) }
+
+      it 'pluralizes the number of days remaining' do
+        expect(helper.time_remaining_for_checkout(checkout)).to eq '42 days'
+      end
+    end
+  end
+
+  describe '#today_with_time_or_date' do
+    context 'when the checkout is a short term loan' do
+      it 'returns a string that says Today and the time' do
+        expect(helper.today_with_time_or_date(Time.zone.now + 42.minutes, short_term: true)).to match(/^Today at \d/)
+      end
+
+      context 'when the due date is on a past date' do
+        it 'returns a formatted date' do
+          expect(
+            helper.today_with_time_or_date(Time.zone.parse('2019-01-01'), short_term: true)
+          ).to eq 'January  1, 2019'
+        end
+      end
+    end
+
+    context 'when the short term flag is false' do
+      it 'returns a formatted date' do
+        expect(helper.today_with_time_or_date(Time.zone.parse('2019-01-01'))).to eq 'January  1, 2019'
+      end
+    end
+  end
+end

--- a/spec/models/checkout_spec.rb
+++ b/spec/models/checkout_spec.rb
@@ -84,6 +84,20 @@ RSpec.describe Checkout do
     end
   end
 
+  describe '#short_term_loan?' do
+    it 'is true when the loan period type is HOURLY' do
+      fields['circulationRule'] = { 'fields' => { 'loanPeriod' => { 'fields' => {
+        'periodType' => { 'key' => 'HOURLY' }
+      } } } }
+
+      expect(checkout).to be_short_term_loan
+    end
+
+    it 'is false when the loan period is any other type (or not defined)' do
+      expect(checkout).not_to be_short_term_loan
+    end
+  end
+
   it 'has a due date' do
     expect(checkout.due_date.strftime('%m/%d/%Y')).to eq '07/09/2019'
   end


### PR DESCRIPTION
Closes #142 

Also updates the Remaining data to use `distance_of_time_in_words` (so we don't get `0 days`)

<img width="508" alt="Screen Shot 2019-07-17 at 4 56 48 PM" src="https://user-images.githubusercontent.com/96776/61474762-25473180-a93e-11e9-8ae5-68e96bb2f622.png">
