### PR TITLE
Make test more flexible to handle single and double digit hours

### DIFF
--- a/spec/helpers/checkouts_helper_spec.rb
+++ b/spec/helpers/checkouts_helper_spec.rb
@@ -42,7 +42,8 @@ RSpec.describe CheckoutsHelper do
   describe '#today_with_time_or_date' do
     context 'when the checkout is a short term loan' do
       it 'returns a string that says Today and the time' do
-        expect(helper.today_with_time_or_date(Time.zone.now + 42.minutes, short_term: true)).to match(/^Today at \d/)
+        expect(helper.today_with_time_or_date(Time.zone.now + 42.minutes, short_term: true))
+          .to match(/^Today at\s{1,2}\d/)
       end
 
       context 'when the due date is on a past date' do


### PR DESCRIPTION
This was failing the build when run on hours that were single digit `7` but passed for double digit `12`