### PR TITLE
 Remove days overdue from Fine.

### DIFF
--- a/app/models/fine.rb
+++ b/app/models/fine.rb
@@ -77,13 +77,6 @@ class Fine
     Time.zone.parse(fields['billDate']) if fields['billDate']
   end
 
-  def days_overdue
-    return unless bill_date
-    return unless bill_date.past?
-
-    ((Time.zone.now - bill_date).to_i / 60 / 60 / 24).round + 1
-  end
-
   def owed
     fields['owed']['amount'].to_d
   end

--- a/app/views/fines/_fine.html.erb
+++ b/app/views/fines/_fine.html.erb
@@ -24,7 +24,7 @@
   </div>
   <div class="collapse w-100" id="collapseExample-<%= fine.key.parameterize %>">
     <dl class="row justify-content-center">
-      <dt class="col-5">Billed on:</dt>
+      <dt class="col-5">Billed:</dt>
       <dd class="col-5"><%= l(fine.bill_date, format: :short) %></dd>
       <dt class="col-5"><%= nice_status_fee_label(fine.nice_status) %>:</dt>
       <dd class="col-5"><%= number_to_currency(fine.fee) %></dd>

--- a/app/views/fines/_fine.html.erb
+++ b/app/views/fines/_fine.html.erb
@@ -26,10 +26,6 @@
     <dl class="row justify-content-center">
       <dt class="col-5">Billed on:</dt>
       <dd class="col-5"><%= l(fine.bill_date, format: :short) %></dd>
-      <% if fine.days_overdue %>
-        <dt class="col-5">Days overdue:</dt>
-        <dd class="col-5"><%= fine.days_overdue %></dd>
-      <% end %>
       <dt class="col-5"><%= nice_status_fee_label(fine.nice_status) %>:</dt>
       <dd class="col-5"><%= number_to_currency(fine.fee) %></dd>
       <dt class="col-5">Source:</dt>

--- a/spec/features/fines_spec.rb
+++ b/spec/features/fines_spec.rb
@@ -35,10 +35,10 @@ RSpec.describe 'Fines Page', type: :feature do
 
     within('ul.fines') do
       expect(page).not_to have_css('dl', visible: true)
-      expect(page).not_to have_css('dt', text: 'Billed on', visible: true)
+      expect(page).not_to have_css('dt', text: 'Billed', visible: true)
       click_button 'Expand'
       expect(page).to have_css('dl', visible: true)
-      expect(page).to have_css('dt', text: 'Billed on', visible: true)
+      expect(page).to have_css('dt', text: 'Billed', visible: true)
     end
   end
 end

--- a/spec/models/fine_spec.rb
+++ b/spec/models/fine_spec.rb
@@ -79,32 +79,6 @@ RSpec.describe Fine do
     expect(fine.owed).to eq 5000.00
   end
 
-  describe '#days_overdue' do
-    it 'returns nil if there is no date' do
-      fields['billDate'] = nil
-
-      expect(fine.days_overdue).to be_nil
-    end
-
-    it 'returns nil if the bill date has not passed' do
-      fields['billDate'] = (Time.zone.today + 4.days).to_s
-
-      expect(fine.days_overdue).to be_nil
-    end
-
-    it 'returns 1 when the the bill date is today' do
-      fields['billDate'] = Time.zone.today.to_s
-
-      expect(fine.days_overdue).to be 1
-    end
-
-    it 'returns the number of days the item is past due ' do
-      fields['billDate'] = (Time.zone.today - 4.days).to_s
-
-      expect(fine.days_overdue).to be 5
-    end
-  end
-
   context 'without a related item' do
     let(:fields) do
       {


### PR DESCRIPTION
It wasn't really correct and we may not have the data to accurately show the user how many days they were fined for.

Also updates the label for Billed on to reflect the labels & content doc.

I believe this closes #130 as the data there now reflects the labels & content doc (but not necessarily the original issue)