### PR TITLE
Add a literal space between the icon and thetext for the link out to …

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -11,7 +11,7 @@ module ApplicationHelper
     content_tag(:div, class: 'row justify-content-center') do
       content_tag(:div, class: 'col-5') do
         link_to Settings.sw.url + catkey, rel: 'noopener', target: '_blank' do
-          sul_icon(:'sharp-open_in_new-24px') + 'View in SearchWorks'
+          sul_icon(:'sharp-open_in_new-24px') + ' View in SearchWorks'
         end
       end + content_tag(:div, class: 'col-5') {}
     end


### PR DESCRIPTION
…searchworks.

This is probably a prerequisite to #191 to make sure we're outputting consistent markup before trying to apply a global style.