### PR TITLE
Update layout of expanded details content; fixes #192

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -8,12 +8,12 @@ module ApplicationHelper
   # Wrap a link to the SearchWorks record for the given Catkey wrapped in the markup
   # necessary to be aligned with the content in the collapsible list sections
   def detail_link_to_searchworks(catkey)
-    content_tag(:div, class: 'row justify-content-center') do
-      content_tag(:div, class: 'col-5') do
+    content_tag(:div, class: 'row') do
+      content_tag(:div, class: 'col-11 offset-1 col-md-10 offset-md-2') do
         link_to Settings.sw.url + catkey, rel: 'noopener', target: '_blank' do
           sul_icon(:'sharp-open_in_new-24px') + 'View in SearchWorks'
         end
-      end + content_tag(:div, class: 'col-5') {}
+      end
     end
   end
 

--- a/app/views/checkouts/_checkout.html.erb
+++ b/app/views/checkouts/_checkout.html.erb
@@ -27,8 +27,8 @@
   </div>
   <div class="collapse w-100" id="collapseExample-<%= checkout.key.parameterize %>">
     <% if checkout.renewable? %>
-      <div class="row justify-content-center">
-        <div class="col-5">
+      <div class="row">
+        <div class="col-11 offset-1 col-md-10 offset-md-2">
           <%= form_tag renewals_path, method: :post do %>
             <%= hidden_field_tag :resource, checkout.resource %>
             <%= hidden_field_tag :item_key, checkout.item_key %>
@@ -38,33 +38,32 @@
             <% end %>
           <% end %>
         </div>
-        <div class="col-5"></div>
       </div>
     <% end %>
-    <dl class="row justify-content-center">
-      <dt class="col-5">Borrowed:</dt>
-      <dd class="col-5">
+    <dl class="row">
+      <dt class="col-3 offset-1 col-md-2 offset-md-2">Borrowed:</dt>
+      <dd class="col-8">
         <%= today_with_time_or_date(checkout.checkout_date, short_term: checkout.short_term_loan?) %>
       </dd>
       <% if checkout.renewal_date  %>
-        <dt class="col-5">Renewed on:</dt>
-        <dd class="col-5"><%= l(checkout.renewal_date, format: :short) %></dd>
+        <dt class="col-3 offset-1 col-md-2 offset-md-2">Renewed on:</dt>
+        <dd class="col-8"><%= l(checkout.renewal_date, format: :short) %></dd>
       <% end %>
       <% if checkout.recalled_date  %>
-        <dt class="col-5">Recalled on:</dt>
-        <dd class="col-5"><%= l(checkout.recalled_date, format: :short) %></dd>
+        <dt class="col-3 offset-1 col-md-2 offset-md-2">Recalled on:</dt>
+        <dd class="col-8"><%= l(checkout.recalled_date, format: :short) %></dd>
       <% end %>
       <% if checkout.overdue? %>
-        <dt class="col-5">Days overdue:</dt>
-        <dd class="col-5"><%= checkout.days_overdue %></dd>
-        <dt class="col-5">Fines accrued:</dt>
-        <dd class="col-5"><%= number_to_currency(checkout.accrued) %> </dd>
+        <dt class="col-3 offset-1 col-md-2 offset-md-2">Days overdue:</dt>
+        <dd class="col-8"><%= checkout.days_overdue %></dd>
+        <dt class="col-3 offset-1 col-md-2 offset-md-2">Fines accrued:</dt>
+        <dd class="col-8"><%= number_to_currency(checkout.accrued) %> </dd>
       <% else %>
-        <dt class="col-5">Remaining:</dt>
-        <dd class="col-5"><%= time_remaining_for_checkout(checkout) %></dd>
+        <dt class="col-3 offset-1 col-md-2 offset-md-2">Remaining:</dt>
+        <dd class="col-8"><%= time_remaining_for_checkout(checkout) %></dd>
       <% end %>
-      <dt class="col-5">Source:</dt>
-      <dd class="col-5"><%= library_name checkout.library %></dd>
+      <dt class="col-3 offset-1 col-md-2 offset-md-2">Source:</dt>
+      <dd class="col-8"><%= library_name checkout.library %></dd>
     </dl>
 
     <%= detail_link_to_searchworks(checkout.catkey) %>

--- a/app/views/fines/_fine.html.erb
+++ b/app/views/fines/_fine.html.erb
@@ -23,13 +23,13 @@
     </button>
   </div>
   <div class="collapse w-100" id="collapseExample-<%= fine.key.parameterize %>">
-    <dl class="row justify-content-center">
-      <dt class="col-5">Billed:</dt>
-      <dd class="col-5"><%= l(fine.bill_date, format: :short) %></dd>
-      <dt class="col-5"><%= nice_status_fee_label(fine.nice_status) %>:</dt>
-      <dd class="col-5"><%= number_to_currency(fine.fee) %></dd>
-      <dt class="col-5">Source:</dt>
-      <dd class="col-5"><%= library_name fine.library %></dd>
+    <dl class="row">
+      <dt class="col-3 offset-1 col-md-2 offset-md-2">Billed:</dt>
+      <dd class="col-8"><%= l(fine.bill_date, format: :short) %></dd>
+      <dt class="col-3 offset-1 col-md-2 offset-md-2"><%= nice_status_fee_label(fine.nice_status) %>:</dt>
+      <dd class="col-8"><%= number_to_currency(fine.fee) %></dd>
+      <dt class="col-3 offset-1 col-md-2 offset-md-2">Source:</dt>
+      <dd class="col-8"><%= library_name fine.library %></dd>
     </dl>
 
     <%= detail_link_to_searchworks(fine.catkey) if fine.bib? %>

--- a/app/views/requests/_request.html.erb
+++ b/app/views/requests/_request.html.erb
@@ -35,15 +35,15 @@
     </button>
   </div>
   <div class="collapse w-100" id="collapseExample-<%= request.key.parameterize %>">
-    <dl class="row justify-content-center">
+    <dl class="row">
       <% if request.placed_date %>
-        <dt class="col-5">Requested on:</dt>
-        <dd class="col-5"><%= l(request.placed_date, format: :short) %></dd>
+        <dt class="col-3 offset-1 col-md-2 offset-md-2">Requested on:</dt>
+        <dd class="col-8"><%= l(request.placed_date, format: :short) %></dd>
       <% end %>
-      <dt class="col-5">Waitlist position:</dt>
-      <dd class="col-5"><%= request.waitlist_position %></dd>
-      <dt class="col-5">Source:</dt>
-      <dd class="col-5"><%= library_name request.placed_library %></dd>
+      <dt class="col-3 offset-1 col-md-2 offset-md-2">Waitlist position:</dt>
+      <dd class="col-8"><%= request.waitlist_position %></dd>
+      <dt class="col-3 offset-1 col-md-2 offset-md-2">Source:</dt>
+      <dd class="col-8"><%= library_name request.placed_library %></dd>
     </dl>
 
     <%= detail_link_to_searchworks(request.catkey) %>

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe ApplicationHelper do
     let(:content) { Capybara.string(helper.detail_link_to_searchworks('12345')) }
 
     it 'has two columns' do
-      expect(content).to have_css('.row .col-5', count: 2)
+      expect(content).to have_css('.row .col-11')
     end
 
     it 'has a link to SerachWorks' do


### PR DESCRIPTION
Fixes #192

Before:
<img width="477" alt="Screen Shot 2019-07-22 at 07 42 12" src="https://user-images.githubusercontent.com/111218/61641635-4cf70c00-ac54-11e9-847c-2bf1ea19d03b.png">


After:
<img width="480" alt="Screen Shot 2019-07-22 at 07 41 54" src="https://user-images.githubusercontent.com/111218/61641609-45cffe00-ac54-11e9-992f-f751a7b9f3ef.png">
