### PR TITLE
Update nav link styling; fixes #194

### DIFF
--- a/app/assets/stylesheets/modules/header_navbar.scss
+++ b/app/assets/stylesheets/modules/header_navbar.scss
@@ -21,15 +21,18 @@
       border-bottom: 1px solid transparent;
     }
   }
+}
 
-  .topnav-links {
-    a {
-      color: $white;
-      margin-left: $spacer;
-    }
+.topnav-links {
+  a {
+    border-bottom: 3px solid transparent;
+    color: $white;
+    margin-left: $spacer;
 
-    a:hover {
-      border-bottom: 1px solid transparent;
+    &:hover,
+    &:focus,
+    &:active {
+      border-bottom: 3px solid $white;
     }
   }
 

--- a/app/assets/stylesheets/modules/navigation.scss
+++ b/app/assets/stylesheets/modules/navigation.scss
@@ -6,6 +6,7 @@
   a:hover,
   a:focus,
   a:active {
+    background-color: rgba($cloud, .3);
     border-bottom: 1px solid transparent;
   }
 

--- a/app/assets/stylesheets/modules/top_navbar.scss
+++ b/app/assets/stylesheets/modules/top_navbar.scss
@@ -3,9 +3,22 @@
   padding: 2px 0;
   height: 35px;
 
+  // move the link padding from the `a` to the `li`
+  // so we can show our custom bottom border on hover
+  .nav-item {
+    padding-bottom: $nav-link-padding-y;
+  }
+
   a {
     color: $cardinal-red;
-    border-bottom: 1px solid transparent;
+    border-bottom: 3px solid transparent;
+    padding-bottom: 0;
+
+    &:hover,
+    &:focus,
+    &:active {
+      border-bottom: 3px solid $cardinal-red;
+    }
   }
 }
 


### PR DESCRIPTION
Nav hover:
<img width="382" alt="Screen Shot 2019-07-22 at 08 07 35" src="https://user-images.githubusercontent.com/111218/61643463-cba17880-ac57-11e9-9849-5bbd30bca61b.png">

Contact links:
<img width="242" alt="Screen Shot 2019-07-22 at 08 07 44" src="https://user-images.githubusercontent.com/111218/61643476-d0662c80-ac57-11e9-88ea-c54de7f87406.png">

Header nav:
<img width="246" alt="Screen Shot 2019-07-22 at 08 07 51" src="https://user-images.githubusercontent.com/111218/61643484-d4924a00-ac57-11e9-80b0-77594ad4cf7d.png">
