### PR TITLE
 Add privileges expire information to the summary; fixes #216

### DIFF
--- a/app/views/summaries/index.html.erb
+++ b/app/views/summaries/index.html.erb
@@ -8,16 +8,16 @@
   <h2><%= "#{@patron.first_name} #{@patron.last_name}" %></h2>
   <dl class="row">
     <% if @patron.patron_type == 'Fee borrower' %>
-      <dt class='col-2 col-sm-1 font-weight-normal'>Type</dt>
+      <dt class='col-2 col-sm-1 font-weight-normal'>Type:</dt>
       <dd class='col-10 col-sm-11 patron-type'><%= @patron.patron_type %></dd>
     <% end %>
-    <dt class="col-2 col-sm-1 font-weight-normal">Status</dt>
+    <dt class="col-2 col-sm-1 font-weight-normal">Status:</dt>
     <dd class="col-10 col-sm-11 patron-status"><%= @patron.status %></dd>
     <% if @patron.borrow_limit %>
-      <dt class="col-2 col-sm-1 font-weight-normal">Borrower limit</dt>
+      <dt class="col-2 col-sm-1 font-weight-normal">Borrower limit:</dt>
       <dd class="col-10 col-sm-11 patron-status"><%= pluralize(@patron.borrow_limit, 'checkout') %></dd>
     <% end %>
-    <dt class="col-2 col-sm-1 font-weight-normal">Email</dt>
+    <dt class="col-2 col-sm-1 font-weight-normal">Email:</dt>
     <dd class="col-10 col-sm-11 email"><%= @patron.email %></dd>
   </dl>
 </div>

--- a/app/views/summaries/index.html.erb
+++ b/app/views/summaries/index.html.erb
@@ -17,6 +17,10 @@
       <dt class="col-2 col-sm-1 font-weight-normal">Borrower limit:</dt>
       <dd class="col-10 col-sm-11 patron-status"><%= pluralize(@patron.borrow_limit, 'checkout') %></dd>
     <% end %>
+    <% if @patron.patron_type == 'Fee borrower' || @patron.proxy_borrower? %>
+      <dt class="col-2 col-sm-1 font-weight-normal">Privileges expire:</dt>
+      <dd class="col-10 col-sm-11 expired-date"><%= l(@patron.expired_date, format: :short) %></dd>
+    <% end %>
     <dt class="col-2 col-sm-1 font-weight-normal">Email:</dt>
     <dd class="col-10 col-sm-11 email"><%= @patron.email %></dd>
   </dl>

--- a/spec/features/summaries_spec.rb
+++ b/spec/features/summaries_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe 'Summaries Page', type: :feature do
     expect(page).to have_css('h2', text: 'Undergrad Superuser')
     expect(page).to have_css('dd.patron-status', text: 'Blocked')
     expect(page).to have_css('dd.email', text: 'superuser1@stanford.edu')
+    expect(page).not_to have_css('dd.expired-date')
     expect(page).not_to have_css('dd.patron-type')
   end
 
@@ -27,6 +28,20 @@ RSpec.describe 'Summaries Page', type: :feature do
     expect(page).to have_css('div', text: '2 ready for pickup')
     expect(page).to have_css('h3', text: 'Fines & fees payable: $7.00')
     expect(page).to have_css('div', text: '$72.00 accruing on overdue items')
+  end
+
+  context 'with a proxy borrower' do
+    before do
+      login_as(username: 'PROXY21', patron_key: '521197')
+      visit summaries_url
+    end
+
+    it 'has patron data' do
+      expect(page).to have_css('h2', text: 'Second (P=FirstProxyLN) Faculty Group')
+      expect(page).to have_css('dd.patron-status', text: 'Blocked')
+      expect(page).to have_css('dd.email', text: 'faculty2@stanford.edu')
+      expect(page).to have_css('dd.expired-date', text: 'February 1, 2020')
+    end
   end
 
   context 'with mock data' do


### PR DESCRIPTION
<img width="360" alt="Screen Shot 2019-07-23 at 15 56 37" src="https://user-images.githubusercontent.com/111218/61752943-7c943a00-ad62-11e9-8285-5ffe9afed775.png">

I'm assuming the privileges expiration date is only set in Symphony for the users we want to show this information.