### PR TITLE
Adds borrower name in the group content.

### DIFF
--- a/app/models/checkout.rb
+++ b/app/models/checkout.rb
@@ -70,6 +70,10 @@ class Checkout
     fields.dig('circulationRule', 'fields', 'renewFromPeriod').to_i
   end
 
+  def patron_key
+    fields['patron']['key']
+  end
+
   def resource
     fields['item']['resource']
   end

--- a/app/models/fine.rb
+++ b/app/models/fine.rb
@@ -41,6 +41,10 @@ class Fine
     record['key']
   end
 
+  def patron_key
+    fields['patron']['key']
+  end
+
   def status
     fields['block']['key']
   end

--- a/app/models/patron.rb
+++ b/app/models/patron.rb
@@ -94,6 +94,16 @@ class Patron
     end
   end
 
+  def member_list_names
+    @member_list_names ||= begin
+      member_list.each_with_object({}) { |member, hash| hash[member.key] = member.first_name }
+    end
+  end
+
+  def member_name(key)
+    member_list_names.fetch(key, '').gsub(/(\A\w+\s)\(P=([a-zA-Z]+)\)\z/, '\2')
+  end
+
   def proxy_borrower?
     fields.dig('groupSettings', 'fields', 'responsibility', 'key') == 'PROXY'
   end

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -16,6 +16,10 @@ class Request
     record['key']
   end
 
+  def patron_key
+    fields['patron']['key']
+  end
+
   def status
     fields['status']
   end

--- a/app/views/checkouts/_checkout.html.erb
+++ b/app/views/checkouts/_checkout.html.erb
@@ -44,6 +44,7 @@
       <% if checkout.claimed_returned? %>
         <dt class="col-11 offset-1 col-md-10 offset-md-2">Claim review is in process</dt>
         <dd></dd>
+      <% end %>
       <% if params[:group] %>
         <dt class="col-3 offset-1 col-md-2 offset-md-2">Borrower:</dt>
         <dd class="col-8"><%= patron.member_name(checkout.patron_key) %></dd>

--- a/app/views/checkouts/_checkout.html.erb
+++ b/app/views/checkouts/_checkout.html.erb
@@ -44,6 +44,9 @@
       <% if checkout.claimed_returned? %>
         <dt class="col-11 offset-1 col-md-10 offset-md-2">Claim review is in process</dt>
         <dd></dd>
+      <% if params[:group] %>
+        <dt class="col-3 offset-1 col-md-2 offset-md-2">Borrower:</dt>
+        <dd class="col-8"><%= patron.member_name(checkout.patron_key) %></dd>
       <% end %>
       <dt class="col-3 offset-1 col-md-2 offset-md-2">Borrowed:</dt>
       <dd class="col-8">

--- a/app/views/fines/_fine.html.erb
+++ b/app/views/fines/_fine.html.erb
@@ -24,6 +24,10 @@
   </div>
   <div class="collapse w-100" id="collapseExample-<%= fine.key.parameterize %>">
     <dl class="row">
+      <% if params[:group] %>
+        <dt class="col-3 offset-1 col-md-2 offset-md-2">Borrower:</dt>
+        <dd class="col-8"><%= patron.member_name(fine.patron_key) %></dd>
+      <% end %>
       <dt class="col-3 offset-1 col-md-2 offset-md-2">Billed:</dt>
       <dd class="col-8"><%= l(fine.bill_date, format: :short) %></dd>
       <dt class="col-3 offset-1 col-md-2 offset-md-2"><%= nice_status_fee_label(fine.nice_status) %>:</dt>

--- a/app/views/requests/_request.html.erb
+++ b/app/views/requests/_request.html.erb
@@ -36,6 +36,10 @@
   </div>
   <div class="collapse w-100" id="collapseExample-<%= request.key.parameterize %>">
     <dl class="row">
+      <% if params[:group] %>
+        <dt class="col-3 offset-1 col-md-2 offset-md-2">Borrower:</dt>
+        <dd class="col-8"><%= patron.member_name(request.patron_key) %></dd>
+      <% end %>
       <% if request.placed_date %>
         <dt class="col-3 offset-1 col-md-2 offset-md-2">Requested on:</dt>
         <dd class="col-8"><%= l(request.placed_date, format: :short) %></dd>

--- a/spec/features/proxy_user_spec.rb
+++ b/spec/features/proxy_user_spec.rb
@@ -28,24 +28,29 @@ RSpec.describe 'Proxy User', type: :feature do
     click_link 'Group'
     expect(page).to have_text('Making plans : how to engage with landscape, design, and the urban environment')
     expect(page).not_to have_text('Programming cultures : art and architecture in the age of software')
+    expect(page).to have_text('SecondproxyLN')
   end
 
   it 'toggles between proxy user and group requests' do
     visit requests_path
 
     expect(page).to have_text('The blockchain and the new architecture of trust')
+    expect(page).not_to have_text('Borrower:')
 
     click_link 'Group'
     expect(page).to have_text('San Filippo di Fragalà')
     expect(page).not_to have_text('The blockchain and the new architecture of trust')
+    expect(page).to have_text('SecondproxyLN')
   end
 
   it 'toggles between proxy user and group fines' do
     visit fines_path
 
     expect(page).to have_text('Aspects of grammatical architecture')
+    expect(page).not_to have_text('Borrower:')
 
     click_link 'Group'
     expect(page).not_to have_text('Aspects of grammatical architecture')
+    expect(page).not_to have_text('SecondproxyLN')
   end
 end

--- a/spec/models/patron_spec.rb
+++ b/spec/models/patron_spec.rb
@@ -266,6 +266,23 @@ RSpec.describe Patron do
       end
     end
 
+    describe '#member_names' do
+      let(:member_list) do
+        [
+          { key: '1', fields: {} },
+          { key: '2', fields: { groupSettings: {
+            fields: { responsibility: { key: 'SPONSOR' } }
+          } } },
+          { key: '3', fields: {} },
+          { key: '411612', fields: { firstName: 'Mark (P=Wangchuk)' } }
+        ]
+      end
+
+      it 'returns a name give a patron key' do
+        expect(patron.member_name('411612')).to eq 'Wangchuk'
+      end
+    end
+
     describe '#group?' do
       context 'when there are group members' do
         let(:member_list) do


### PR DESCRIPTION
Part of #159 
Displays borrower name on group tab:
<img width="1135" alt="Screen Shot 2019-07-23 at 10 58 56 PM" src="https://user-images.githubusercontent.com/6343464/61768904-930bb700-ad9d-11e9-82c7-d43bbe5e217d.png">
Does not display borrower name for self:
<img width="1117" alt="Screen Shot 2019-07-23 at 10 58 38 PM" src="https://user-images.githubusercontent.com/6343464/61768905-930bb700-ad9d-11e9-81ee-03ee8276b473.png">