### PR TITLE
Add information about the number of checkouts remaining to the summary + checkouts page

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -37,5 +37,9 @@ RSpec/MultipleExpectations:
   Exclude:
     - 'spec/features/**/*'
 
+RSpec/DescribeClass:
+  Exclude:
+    - 'spec/views/**/*'
+
 Layout/IndentFirstHashElement:
   EnforcedStyle: consistent

--- a/app/models/patron.rb
+++ b/app/models/patron.rb
@@ -77,6 +77,12 @@ class Patron
     profile['chargeLimit'].to_i
   end
 
+  def remaining_checkouts
+    return unless  borrow_limit
+
+    borrow_limit - checkouts.length
+  end
+
   def group?
     member_list.any?
   end

--- a/app/views/checkouts/index.html.erb
+++ b/app/views/checkouts/index.html.erb
@@ -29,7 +29,7 @@
 
 <div id="checkouts" class="page-section">
   <div class="d-flex justify-content-between">
-    <h2>Checked out: <%= other_checkouts.length %></h2>
+    <h2>Checked out: <%= other_checkouts.length %><%= " (#{patron.remaining_checkouts} remaining)" if patron.remaining_checkouts %></h2>
     <div class="dropdown">
       <a class="btn btn-secondary dropdown-toggle" href="#" role="button" id="dropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
         Sort (<span data-sort-label>Due date</span>)

--- a/app/views/summaries/index.html.erb
+++ b/app/views/summaries/index.html.erb
@@ -23,7 +23,7 @@
 </div>
 
 <div class="page-section">
-  <h3><%= sul_icon :'sharp-playlist_add_check-24px', classes: 'lg' %> Checkouts: <%= @patron.checkouts.length %></h3>
+  <h3><%= sul_icon :'sharp-playlist_add_check-24px', classes: 'lg' %> Checkouts: <%= @patron.checkouts.length %><%= " (#{@patron.remaining_checkouts} remaining)" if @patron.remaining_checkouts %></h3>
   <% count = @patron.checkouts.select(&:recalled?).length %>
   <% if count.positive? %>
     <div><%= sul_icon :'sharp-error-24px', classes: 'text-recalled' %> <%= count %> recalled</div>

--- a/spec/views/checkouts/index.html.erb_spec.rb
+++ b/spec/views/checkouts/index.html.erb_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'checkouts/index.html.erb' do
+  let(:patron) { instance_double(Patron, remaining_checkouts: nil) }
+
+  before do
+    controller.singleton_class.class_eval do
+      protected
+
+      def patron; end
+      helper_method :patron
+    end
+
+    stub_template 'shared/_navigation.html.erb' => 'Navigation'
+    allow(view).to receive(:patron).and_return(patron)
+
+    assign(:checkouts, [])
+  end
+
+  it 'shows the number of checkouts' do
+    render
+
+    expect(rendered).to include('<h2>Checked out: 0</h2>')
+  end
+
+  context 'with a fee borrower' do
+    before do
+      allow(patron).to receive(:remaining_checkouts).and_return(25)
+    end
+
+    it 'shows the number of checkouts remaining' do
+      render
+
+      expect(rendered).to include('<h2>Checked out: 0 (25 remaining)</h2>')
+    end
+  end
+end


### PR DESCRIPTION
<img width="566" alt="Screen Shot 2019-07-23 at 16 32 35" src="https://user-images.githubusercontent.com/111218/61754310-82d8e500-ad67-11e9-9996-5a6aa3ba2b0a.png">
<img width="415" alt="Screen Shot 2019-07-23 at 16 32 32" src="https://user-images.githubusercontent.com/111218/61754314-840a1200-ad67-11e9-84b2-8fcd3fcabbf3.png">
