### PR TITLE
Truncate authors to one line

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -5,6 +5,7 @@
 @import 'bootstrap';
 @import 'base';
 @import 'su-identity-overrides';
+@import 'modules/clamp';
 @import 'modules/header_navbar';
 @import 'modules/page-section';
 @import 'modules/navigation';

--- a/app/assets/stylesheets/mixins.scss
+++ b/app/assets/stylesheets/mixins.scss
@@ -18,3 +18,13 @@
   letter-spacing: -.03em;
   line-height: 1.5em;
 }
+
+@mixin truncate-by-lines($lines) {
+  -webkit-box-orient: vertical;
+  box-orient: vertical;
+  display: -webkit-box;
+  -webkit-line-clamp: $lines;
+  line-clamp: $lines;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}

--- a/app/assets/stylesheets/mixins.scss
+++ b/app/assets/stylesheets/mixins.scss
@@ -20,11 +20,17 @@
 }
 
 @mixin truncate-by-lines($lines) {
-  -webkit-box-orient: vertical;
-  box-orient: vertical;
-  display: -webkit-box;
-  -webkit-line-clamp: $lines;
-  line-clamp: $lines;
-  overflow: hidden;
-  text-overflow: ellipsis;
+  @if $lines == 1 {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  } @else {
+    -webkit-box-orient: vertical;
+    box-orient: vertical;
+    display: -webkit-box;
+    -webkit-line-clamp: $lines;
+    line-clamp: $lines;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
 }

--- a/app/assets/stylesheets/modules/clamp.scss
+++ b/app/assets/stylesheets/modules/clamp.scss
@@ -1,0 +1,7 @@
+.clamp-1 {
+  @include truncate-by-lines(1);
+}
+
+.clamp-2 {
+  @include truncate-by-lines(2);
+}

--- a/app/assets/stylesheets/modules/record.scss
+++ b/app/assets/stylesheets/modules/record.scss
@@ -5,6 +5,10 @@
   @include truncate-by-lines(2);
 }
 
+.record-author {
+  @include truncate-by-lines(1);
+}
+
 .list-header {
   margin-left: 0;
   margin-right: 0;

--- a/app/assets/stylesheets/modules/record.scss
+++ b/app/assets/stylesheets/modules/record.scss
@@ -2,13 +2,7 @@
 .record-title {
   @include h3-index-title-font;
   @include h3-index-title-small-font;
-  -webkit-box-orient: vertical;
-  box-orient: vertical;
-  display: -webkit-box;
-  -webkit-line-clamp: 2;
-  line-clamp: 2;
-  overflow: hidden;
-  text-overflow: ellipsis;
+  @include truncate-by-lines(2);
 }
 
 .list-header {

--- a/app/assets/stylesheets/modules/record.scss
+++ b/app/assets/stylesheets/modules/record.scss
@@ -2,11 +2,6 @@
 .record-title {
   @include h3-index-title-font;
   @include h3-index-title-small-font;
-  @include truncate-by-lines(2);
-}
-
-.record-author {
-  @include truncate-by-lines(1);
 }
 
 .list-header {

--- a/app/views/checkouts/_checkout.html.erb
+++ b/app/views/checkouts/_checkout.html.erb
@@ -15,7 +15,7 @@
   <div class="d-flex flex-grow-1 flex-column flex-md-row w-75 row col-md-8">
     <h3 class="col-md-7 record-title title"><%= checkout.title %></h3>
     <div class="d-flex flex-row row col-md-5">
-      <div class="w-50 col-md-6 author"><%= checkout.author %></div>
+      <div class="w-50 col-md-6 record-author author"><%= checkout.author %></div>
       <div class="w-50 col-md-6 call_number" data-shelfkey="<%= checkout.shelf_key %>"><%= checkout.call_number %></div>
     </div>
   </div>

--- a/app/views/checkouts/_checkout.html.erb
+++ b/app/views/checkouts/_checkout.html.erb
@@ -13,9 +13,9 @@
     </div>
   </div>
   <div class="d-flex flex-grow-1 flex-column flex-md-row w-75 row col-md-8">
-    <h3 class="col-md-7 record-title title"><%= checkout.title %></h3>
+    <h3 class="col-md-7 clamp-2 record-title title"><%= checkout.title %></h3>
     <div class="d-flex flex-row row col-md-5">
-      <div class="w-50 col-md-6 record-author author"><%= checkout.author %></div>
+      <div class="w-50 col-md-6 clamp-1 author"><%= checkout.author %></div>
       <div class="w-50 col-md-6 call_number" data-shelfkey="<%= checkout.shelf_key %>"><%= checkout.call_number %></div>
     </div>
   </div>

--- a/app/views/fines/_fine.html.erb
+++ b/app/views/fines/_fine.html.erb
@@ -11,7 +11,7 @@
     <% if fine.bib? %>
       <h3 class="col-md-7 record-title title"><%= fine.title %></h3>
       <div class="d-flex flex-row row col-md-5">
-        <div class="w-50 col-md-6 author"><%= fine.author %></div>
+        <div class="w-50 col-md-6 record-author author"><%= fine.author %></div>
         <div class="w-50 col-md-6 call_number" data-shelfkey="<%= fine.shelf_key %>"><%= fine.call_number %></div>
       </div>
     <% end %>

--- a/app/views/fines/_fine.html.erb
+++ b/app/views/fines/_fine.html.erb
@@ -9,9 +9,9 @@
   </div>
   <div class="d-flex flex-grow-1 flex-column flex-md-row w-75 row col-md-8">
     <% if fine.bib? %>
-      <h3 class="col-md-7 record-title title"><%= fine.title %></h3>
+      <h3 class="col-md-7 clamp-2 record-title title"><%= fine.title %></h3>
       <div class="d-flex flex-row row col-md-5">
-        <div class="w-50 col-md-6 record-author author"><%= fine.author %></div>
+        <div class="w-50 col-md-6 clamp-1 author"><%= fine.author %></div>
         <div class="w-50 col-md-6 call_number" data-shelfkey="<%= fine.shelf_key %>"><%= fine.call_number %></div>
       </div>
     <% end %>

--- a/app/views/fines/_payment.html.erb
+++ b/app/views/fines/_payment.html.erb
@@ -13,7 +13,7 @@
     </div>
   </div>
   <div class="d-flex flex-grow-1 flex-column flex-md-row w-75 row col-md-6">
-    <h3 class="col-md-10 record-title list-item-title"><%= payment.item_title %></h3>
+    <h3 class="col-md-10 clamp-2 record-title list-item-title"><%= payment.item_title %></h3>
   </div>
   <div>
     <button class="btn collapsed" type="button" data-toggle="collapse" data-target="#collapseExample-<%= payment.key.parameterize %>" aria-expanded="false" aria-controls="collapseExample-<%= payment.key.parameterize %>">

--- a/app/views/requests/_request.html.erb
+++ b/app/views/requests/_request.html.erb
@@ -22,9 +22,9 @@
     <% end %>
   </div>
   <div class="d-flex flex-grow-1 flex-column flex-md-row w-75 row col-md-8">
-    <h3 class="col-md-7 record-title title"><%= request.title %></h3>
+    <h3 class="col-md-7 clamp-2 record-title title"><%= request.title %></h3>
     <div class="d-flex flex-row row col-md-5">
-      <div class="w-50 col-md-6 record-author author"><%= request.author %></div>
+      <div class="w-50 col-md-6 clamp-1 author"><%= request.author %></div>
       <div class="w-50 col-md-6 call_number" data-shelfkey="<%= request.shelf_key %>"><%= request.call_number %></div>
     </div>
   </div>

--- a/app/views/requests/_request.html.erb
+++ b/app/views/requests/_request.html.erb
@@ -24,7 +24,7 @@
   <div class="d-flex flex-grow-1 flex-column flex-md-row w-75 row col-md-8">
     <h3 class="col-md-7 record-title title"><%= request.title %></h3>
     <div class="d-flex flex-row row col-md-5">
-      <div class="w-50 col-md-6 author"><%= request.author %></div>
+      <div class="w-50 col-md-6 record-author author"><%= request.author %></div>
       <div class="w-50 col-md-6 call_number" data-shelfkey="<%= request.shelf_key %>"><%= request.call_number %></div>
     </div>
   </div>


### PR DESCRIPTION
Closes #217 

Note that the call number is two lines already, so we have space for two lines of the author name if needed.

<img width="263" alt="Screen Shot 2019-07-24 at 1 21 40 PM" src="https://user-images.githubusercontent.com/96776/61825876-149f2b80-ae16-11e9-91e0-40be4fbd9b53.png">
