### PR TITLE
Improvements for sponsor, proxy and group display

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,7 +2,7 @@
 
 # :nodoc:
 class ApplicationController < ActionController::Base
-  helper_method :current_user, :current_user?, :patron, :symphony_client
+  helper_method :current_user, :current_user?, :patron, :patron_or_group, :symphony_client
 
   def current_user
     session_data = request.env['warden'].user
@@ -17,6 +17,16 @@ class ApplicationController < ActionController::Base
     return unless current_user?
 
     @patron ||= Patron.new(symphony_client.patron_info(current_user.patron_key))
+  end
+
+  def patron_or_group
+    return unless patron
+
+    if params[:group]
+      patron.group
+    else
+      patron
+    end
   end
 
   private

--- a/app/controllers/checkouts_controller.rb
+++ b/app/controllers/checkouts_controller.rb
@@ -5,10 +5,6 @@ class CheckoutsController < ApplicationController
   before_action :authenticate_user!
 
   def index
-    @checkouts = if params[:group]
-                   patron.group.checkouts.sort_by(&:due_date)
-                 else
-                   patron.checkouts.sort_by(&:due_date)
-                 end
+    @checkouts = patron_or_group.checkouts.sort_by(&:due_date)
   end
 end

--- a/app/controllers/checkouts_controller.rb
+++ b/app/controllers/checkouts_controller.rb
@@ -6,7 +6,7 @@ class CheckoutsController < ApplicationController
 
   def index
     @checkouts = if params[:group]
-                   patron.group_checkouts.sort_by(&:due_date)
+                   patron.group.checkouts.sort_by(&:due_date)
                  else
                    patron.checkouts.sort_by(&:due_date)
                  end

--- a/app/controllers/fines_controller.rb
+++ b/app/controllers/fines_controller.rb
@@ -17,19 +17,11 @@ class FinesController < ApplicationController
   private
 
   def fines
-    if params[:group]
-      patron.group.fines
-    else
-      patron.fines
-    end
+    patron_or_group.fines
   end
 
   def checkouts
-    if params[:group]
-      patron.group.checkouts.sort_by(&:due_date)
-    else
-      patron.checkouts.sort_by(&:due_date)
-    end
+    patron_or_group.checkouts.sort_by(&:due_date)
   end
 
   def payments_response

--- a/app/controllers/fines_controller.rb
+++ b/app/controllers/fines_controller.rb
@@ -18,7 +18,7 @@ class FinesController < ApplicationController
 
   def fines
     if params[:group]
-      patron.group_fines
+      patron.group.fines
     else
       patron.fines
     end
@@ -26,7 +26,7 @@ class FinesController < ApplicationController
 
   def checkouts
     if params[:group]
-      patron.group_checkouts.sort_by(&:due_date)
+      patron.group.checkouts.sort_by(&:due_date)
     else
       patron.checkouts.sort_by(&:due_date)
     end

--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -10,7 +10,7 @@ class RequestsController < ApplicationController
 
   def index
     @requests = if params[:group]
-                  patron.group_requests.sort_by do |request|
+                  patron.group.requests.sort_by do |request|
                     [request.expiration_date || END_OF_DAYS, request.fill_by_date || END_OF_DAYS]
                   end
                 else

--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -9,14 +9,8 @@ class RequestsController < ApplicationController
   END_OF_DAYS = Time.zone.parse('2099-01-01')
 
   def index
-    @requests = if params[:group]
-                  patron.group.requests.sort_by do |request|
-                    [request.expiration_date || END_OF_DAYS, request.fill_by_date || END_OF_DAYS]
-                  end
-                else
-                  patron.requests.sort_by do |request|
-                    [request.expiration_date || END_OF_DAYS, request.fill_by_date || END_OF_DAYS]
-                  end
-                end
+    @requests = patron_or_group.requests.sort_by do |request|
+      [request.expiration_date || END_OF_DAYS, request.fill_by_date || END_OF_DAYS]
+    end
   end
 end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+# Class to model Research group information
+class Group < Patron
+  def patron_type
+    'Research group'
+  end
+
+  def sponsor
+    members.find(&:sponsor?)
+  end
+
+  def checkouts
+    @checkouts ||= member_list.flat_map(&:checkouts)
+  end
+
+  def fines
+    @fines ||= member_list.flat_map(&:fines)
+  end
+
+  def requests
+    @requests ||= member_list.flat_map(&:requests)
+  end
+
+  def member_list
+    @member_list ||= members.reject { |patron| patron.key == key || patron.sponsor? }
+  end
+
+  def member_list_names
+    @member_list_names ||= begin
+      member_list.each_with_object({}) { |member, hash| hash[member.key] = member.first_name }
+    end
+  end
+
+  def member_name(key)
+    member_list_names.fetch(key, '').gsub(/(\A\w+\s)\(P=([a-zA-Z]+)\)\z/, '\2')
+  end
+
+  def to_partial_path
+    'group/group'
+  end
+
+  private
+
+  def members
+    @members ||= begin
+      members = fields.dig('groupSettings', 'fields', 'group', 'fields', 'memberList') || []
+      members.map { |member| Patron.new(member) }
+    end
+  end
+end

--- a/app/models/patron.rb
+++ b/app/models/patron.rb
@@ -154,6 +154,10 @@ class Patron
     @group_requests ||= member_list.flat_map(&:requests)
   end
 
+  def to_partial_path
+    'patron/patron'
+  end
+
   private
 
   def fields

--- a/app/models/patron.rb
+++ b/app/models/patron.rb
@@ -97,27 +97,6 @@ class Patron
     borrow_limit - checkouts.length
   end
 
-  def group?
-    member_list.any?
-  end
-
-  def member_list
-    @member_list ||= begin
-      members = fields.dig('groupSettings', 'fields', 'group', 'fields', 'memberList') || []
-      members.map { |member| Patron.new(member) }.reject { |patron| patron.key == key || patron.sponsor? }
-    end
-  end
-
-  def member_list_names
-    @member_list_names ||= begin
-      member_list.each_with_object({}) { |member, hash| hash[member.key] = member.first_name }
-    end
-  end
-
-  def member_name(key)
-    member_list_names.fetch(key, '').gsub(/(\A\w+\s)\(P=([a-zA-Z]+)\)\z/, '\2')
-  end
-
   def proxy_borrower?
     fields.dig('groupSettings', 'fields', 'responsibility', 'key') == 'PROXY'
   end
@@ -142,16 +121,12 @@ class Patron
     @requests ||= fields['holdRecordList'].map { |request| Request.new(request) }
   end
 
-  def group_checkouts
-    @group_checkouts ||= member_list.flat_map(&:checkouts)
+  def group
+    @group ||= Group.new(record)
   end
 
-  def group_fines
-    @group_fines ||= member_list.flat_map(&:fines)
-  end
-
-  def group_requests
-    @group_requests ||= member_list.flat_map(&:requests)
+  def group?
+    group.member_list.any?
   end
 
   def to_partial_path

--- a/app/models/patron.rb
+++ b/app/models/patron.rb
@@ -59,7 +59,13 @@ class Patron
   end
 
   def patron_type
-    user_profile
+    if user_profile.present?
+      user_profile
+    elsif proxy_borrower?
+      'Research group proxy'
+    elsif sponsor?
+      'Research group sponsor'
+    end
   end
 
   def fee_borrower?

--- a/app/views/checkouts/_checkout.html.erb
+++ b/app/views/checkouts/_checkout.html.erb
@@ -47,7 +47,7 @@
       <% end %>
       <% if params[:group] %>
         <dt class="col-3 offset-1 col-md-2 offset-md-2">Borrower:</dt>
-        <dd class="col-8"><%= patron.member_name(checkout.patron_key) %></dd>
+        <dd class="col-8"><%= patron.group.member_name(checkout.patron_key) %></dd>
       <% end %>
       <dt class="col-3 offset-1 col-md-2 offset-md-2">Borrowed:</dt>
       <dd class="col-8">

--- a/app/views/checkouts/index.html.erb
+++ b/app/views/checkouts/index.html.erb
@@ -29,7 +29,7 @@
 
 <div id="checkouts" class="page-section">
   <div class="d-flex justify-content-between">
-    <h2>Checked out: <%= other_checkouts.length %><%= " (#{patron.remaining_checkouts} remaining)" if patron.remaining_checkouts %></h2>
+    <h2>Checked out: <%= other_checkouts.length %><%= " (#{patron_or_group.remaining_checkouts} remaining)" if patron_or_group.remaining_checkouts %></h2>
     <div class="dropdown">
       <a class="btn btn-secondary dropdown-toggle" href="#" role="button" id="dropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
         Sort (<span data-sort-label>Due date</span>)

--- a/app/views/fines/_fine.html.erb
+++ b/app/views/fines/_fine.html.erb
@@ -26,7 +26,7 @@
     <dl class="row">
       <% if params[:group] %>
         <dt class="col-3 offset-1 col-md-2 offset-md-2">Borrower:</dt>
-        <dd class="col-8"><%= patron.member_name(fine.patron_key) %></dd>
+        <dd class="col-8"><%= patron.group.member_name(fine.patron_key) %></dd>
       <% end %>
       <dt class="col-3 offset-1 col-md-2 offset-md-2">Billed:</dt>
       <dd class="col-8"><%= l(fine.bill_date, format: :short) %></dd>

--- a/app/views/group/_group.html.erb
+++ b/app/views/group/_group.html.erb
@@ -1,0 +1,9 @@
+<h2><%= "#{group.sponsor.display_name}" %></h2>
+<dl class="row">
+  <% if patron.patron_type %>
+    <dt class='col-2 col-sm-1 font-weight-normal'>Patron Type:</dt>
+    <dd class='col-10 col-sm-11 patron-type'><%= group.patron_type %></dd>
+  <% end %>
+  <dt class="col-2 col-sm-1 font-weight-normal">Status:</dt>
+  <dd class="col-10 col-sm-11 patron-status"><%= group.status %></dd>
+</dl>

--- a/app/views/patron/_patron.html.erb
+++ b/app/views/patron/_patron.html.erb
@@ -1,0 +1,19 @@
+<h2><%= "#{patron.first_name} #{patron.last_name}" %></h2>
+<dl class="row">
+  <% if patron.patron_type %>
+    <dt class='col-2 col-sm-1 font-weight-normal'>Patron Type:</dt>
+    <dd class='col-10 col-sm-11 patron-type'><%= patron.patron_type %></dd>
+  <% end %>
+  <dt class="col-2 col-sm-1 font-weight-normal">Status:</dt>
+  <dd class="col-10 col-sm-11 patron-status"><%= patron.status %></dd>
+  <% if patron.borrow_limit %>
+    <dt class="col-2 col-sm-1 font-weight-normal">Borrower limit:</dt>
+    <dd class="col-10 col-sm-11 patron-status"><%= pluralize(patron.borrow_limit, 'checkout') %></dd>
+  <% end %>
+  <% if patron.expired_date && (patron.fee_borrower? || patron.proxy_borrower?) %>
+    <dt class="col-2 col-sm-1 font-weight-normal">Privileges expire:</dt>
+    <dd class="col-10 col-sm-11 expired-date"><%= l(patron.expired_date, format: :short) %></dd>
+  <% end %>
+  <dt class="col-2 col-sm-1 font-weight-normal">Email:</dt>
+  <dd class="col-10 col-sm-11 email"><%= patron.email %></dd>
+</dl>

--- a/app/views/requests/_request.html.erb
+++ b/app/views/requests/_request.html.erb
@@ -38,7 +38,7 @@
     <dl class="row">
       <% if params[:group] %>
         <dt class="col-3 offset-1 col-md-2 offset-md-2">Borrower:</dt>
-        <dd class="col-8"><%= patron.member_name(request.patron_key) %></dd>
+        <dd class="col-8"><%= patron.group.member_name(request.patron_key) %></dd>
       <% end %>
       <% if request.placed_date %>
         <dt class="col-3 offset-1 col-md-2 offset-md-2">Requested on:</dt>

--- a/app/views/shared/_navigation.html.erb
+++ b/app/views/shared/_navigation.html.erb
@@ -4,21 +4,21 @@
       <%= link_to root_path, class: "nav-link #{active_page_class('summaries')}" do %>
         <%= sul_icon :'sharp-person-24px', classes: 'lg' %>
         <span class="label">Summary</span>
-        <span class="info"><%= patron.status %></span>
+        <span class="info"><%= patron_or_group.status %></span>
       <% end %>
     </li>
     <li class="nav-item">
       <%= link_to checkouts_path, class: "nav-link #{active_page_class('checkouts')}" do %>
         <%= sul_icon :'sharp-playlist_add_check-24px', classes: 'lg' %>
         <span class="label">Checkouts</span>
-        <% recalled_count = patron.checkouts.select(&:recalled?).length %>
-        <% overdue_count = patron.checkouts.select(&:overdue?).length %>
+        <% recalled_count = patron_or_group.checkouts.select(&:recalled?).length %>
+        <% overdue_count = patron_or_group.checkouts.select(&:overdue?).length %>
         <% if recalled_count.positive? %>
           <span class="info text-recalled"><%= sul_icon :'sharp-error-24px' %> <%= pluralize(recalled_count, 'recall') %></span>
         <% elsif overdue_count.positive? %>
           <span class="info text-overdue"><%= sul_icon :'sharp-warning-24px' %> <%= overdue_count %> overdue</span>
         <% else %>
-          <span class="info"><%= patron.checkouts.length %></span>
+          <span class="info"><%= patron_or_group.checkouts.length %></span>
         <% end %>
       <% end %>
     </li>
@@ -26,11 +26,11 @@
       <%= link_to requests_path, class: "nav-link #{active_page_class('requests')}" do %>
         <%= sul_icon :'sharp-access_time-24px', classes: 'lg' %>
         <span class="label">Requests</span>
-        <% pickup_count = patron.requests.select(&:ready_for_pickup?).length %>
+        <% pickup_count = patron_or_group.requests.select(&:ready_for_pickup?).length %>
         <% if pickup_count.positive? %>
           <span class="info text-ready"><%= sul_icon :'sharp-check_circle-24px' %> <%= pickup_count %> ready</span>
         <% else %>
-          <span class="info"><%= patron.requests.length %></span>
+          <span class="info"><%= patron_or_group.requests.length %></span>
         <% end %>
       <% end %>
     </li>
@@ -38,8 +38,8 @@
       <%= link_to fines_path, class: "nav-link #{active_page_class('fines')}" do %>
         <%= sul_icon :'sharp-attach_money-24px', classes: 'lg' %>
         <span class="label">Fines</span>
-        <% owed = patron.fines.sum(&:owed) %>
-        <% accruing = patron.checkouts.sum(&:accrued) %>
+        <% owed = patron_or_group.fines.sum(&:owed) %>
+        <% accruing = patron_or_group.checkouts.sum(&:accrued) %>
         <% if owed.positive? %>
           <span class="info text-recalled"><%= sul_icon :'sharp-error-24px' %> <%= number_to_currency(owed) %></span>
         <% elsif accruing.positive? %>
@@ -52,11 +52,11 @@
   </ul>
 </nav>
 
-<% if patron.group? %>
+<% if patron_or_group.group? %>
   <nav class="container">
     <ul class="nav nav-tabs nav-justified col-12 pt-3">
       <li class="nav-item">
-        <%= link_to patron.proxy_borrower_name || 'Self', url_for(group: nil), class: "nav-link #{params[:group].nil? && 'active'}" %>
+        <%= link_to patron_or_group.proxy_borrower_name || 'Self', url_for(group: nil), class: "nav-link #{params[:group].nil? && 'active'}" %>
       </li>
       <li class="nav-item">
         <%= link_to 'Group', url_for(group: true), class: "nav-link #{params[:group] && 'active'}" %>

--- a/app/views/summaries/_summary.html.erb
+++ b/app/views/summaries/_summary.html.erb
@@ -1,0 +1,28 @@
+<div class="page-section">
+  <h3><%= sul_icon :'sharp-playlist_add_check-24px', classes: 'lg' %> Checkouts: <%= patron.checkouts.length %><%= " (#{patron.remaining_checkouts} remaining)" if patron.remaining_checkouts %></h3>
+  <% count = patron.checkouts.select(&:recalled?).length %>
+  <% if count.positive? %>
+    <div><%= sul_icon :'sharp-error-24px', classes: 'text-recalled' %> <%= count %> recalled</div>
+  <% end %>
+
+  <% count = patron.checkouts.select(&:overdue?).length %>
+  <% if count.positive? %>
+    <div><%= sul_icon :'sharp-warning-24px', classes: 'text-overdue' %> <%= count %> overdue</div>
+  <% end %>
+</div>
+
+<div class="page-section">
+  <h3><%= sul_icon :'sharp-access_time-24px', classes: 'lg' %> Requests: <%= patron.requests.length %></h3>
+  <% count = patron.requests.select(&:ready_for_pickup?).length %>
+  <% if count.positive? %>
+    <div><%= sul_icon :'sharp-check_circle-24px', classes: 'text-ready' %> <%= count %> ready for pickup</div>
+  <% end %>
+</div>
+
+<div class="page-section">
+  <h3><%= sul_icon :'sharp-attach_money-24px', classes: 'lg' %> Fines &amp; fees payable: <%= number_to_currency(patron.fines.sum(&:owed)) %></h3>
+  <% accruing = patron.checkouts.sum(&:accrued) %>
+  <% if accruing.positive? %>
+    <div><%= sul_icon :'sharp-warning-24px', classes: 'text-overdue' %> <%= number_to_currency(accruing) %> accruing on overdue items</div>
+  <% end %>
+</div>

--- a/app/views/summaries/index.html.erb
+++ b/app/views/summaries/index.html.erb
@@ -5,55 +5,10 @@
 <% end %>
 
 <div class="page-section">
-  <h2><%= "#{@patron.first_name} #{@patron.last_name}" %></h2>
-  <dl class="row">
-    <% if @patron.patron_type %>
-      <dt class='col-2 col-sm-1 font-weight-normal'>Patron Type:</dt>
-      <dd class='col-10 col-sm-11 patron-type'><%= @patron.patron_type %></dd>
-    <% end %>
-    <dt class="col-2 col-sm-1 font-weight-normal">Status:</dt>
-    <dd class="col-10 col-sm-11 patron-status"><%= @patron.status %></dd>
-    <% if @patron.borrow_limit %>
-      <dt class="col-2 col-sm-1 font-weight-normal">Borrower limit:</dt>
-      <dd class="col-10 col-sm-11 patron-status"><%= pluralize(@patron.borrow_limit, 'checkout') %></dd>
-    <% end %>
-    <% if @patron.expired_date && (@patron.fee_borrower? || @patron.proxy_borrower?) %>
-      <dt class="col-2 col-sm-1 font-weight-normal">Privileges expire:</dt>
-      <dd class="col-10 col-sm-11 expired-date"><%= l(@patron.expired_date, format: :short) %></dd>
-    <% end %>
-    <dt class="col-2 col-sm-1 font-weight-normal">Email:</dt>
-    <dd class="col-10 col-sm-11 email"><%= @patron.email %></dd>
-  </dl>
+  <%= render @patron %>
 </div>
 
-<div class="page-section">
-  <h3><%= sul_icon :'sharp-playlist_add_check-24px', classes: 'lg' %> Checkouts: <%= @patron.checkouts.length %><%= " (#{@patron.remaining_checkouts} remaining)" if @patron.remaining_checkouts %></h3>
-  <% count = @patron.checkouts.select(&:recalled?).length %>
-  <% if count.positive? %>
-    <div><%= sul_icon :'sharp-error-24px', classes: 'text-recalled' %> <%= count %> recalled</div>
-  <% end %>
-
-  <% count = @patron.checkouts.select(&:overdue?).length %>
-  <% if count.positive? %>
-    <div><%= sul_icon :'sharp-warning-24px', classes: 'text-overdue' %> <%= count %> overdue</div>
-  <% end %>
-</div>
-
-<div class="page-section">
-  <h3><%= sul_icon :'sharp-access_time-24px', classes: 'lg' %> Requests: <%= @patron.requests.length %></h3>
-  <% count = @patron.requests.select(&:ready_for_pickup?).length %>
-  <% if count.positive? %>
-    <div><%= sul_icon :'sharp-check_circle-24px', classes: 'text-ready' %> <%= count %> ready for pickup</div>
-  <% end %>
-</div>
-
-<div class="page-section">
-  <h3><%= sul_icon :'sharp-attach_money-24px', classes: 'lg' %> Fines &amp; fees payable: <%= number_to_currency(@patron.fines.sum(&:owed)) %></h3>
-  <% accruing = @patron.checkouts.sum(&:accrued) %>
-  <% if accruing.positive? %>
-    <div><%= sul_icon :'sharp-warning-24px', classes: 'text-overdue' %> <%= number_to_currency(accruing) %> accruing on overdue items</div>
-  <% end %>
-</div>
+<%= render 'summary', patron: @patron %>
 
 <div class="page-section">
   <h2>Policies &amp; information</h2>

--- a/app/views/summaries/index.html.erb
+++ b/app/views/summaries/index.html.erb
@@ -5,10 +5,14 @@
 <% end %>
 
 <div class="page-section">
-  <%= render @patron %>
+  <% if params[:group] %>
+    <%= render @patron.group %>
+  <% else %>
+    <%= render @patron %>
+  <% end %>
 </div>
 
-<%= render 'summary', patron: @patron %>
+<%= render 'summary', patron: params[:group] ? @patron.group : @patron %>
 
 <div class="page-section">
   <h2>Policies &amp; information</h2>

--- a/app/views/summaries/index.html.erb
+++ b/app/views/summaries/index.html.erb
@@ -7,8 +7,8 @@
 <div class="page-section">
   <h2><%= "#{@patron.first_name} #{@patron.last_name}" %></h2>
   <dl class="row">
-    <% if @patron.fee_borrower? %>
-      <dt class='col-2 col-sm-1 font-weight-normal'>Type:</dt>
+    <% if @patron.patron_type %>
+      <dt class='col-2 col-sm-1 font-weight-normal'>Patron Type:</dt>
       <dd class='col-10 col-sm-11 patron-type'><%= @patron.patron_type %></dd>
     <% end %>
     <dt class="col-2 col-sm-1 font-weight-normal">Status:</dt>

--- a/app/views/summaries/index.html.erb
+++ b/app/views/summaries/index.html.erb
@@ -5,14 +5,10 @@
 <% end %>
 
 <div class="page-section">
-  <% if params[:group] %>
-    <%= render @patron.group %>
-  <% else %>
-    <%= render @patron %>
-  <% end %>
+  <%= render patron_or_group %>
 </div>
 
-<%= render 'summary', patron: params[:group] ? @patron.group : @patron %>
+<%= render 'summary', patron: patron_or_group %>
 
 <div class="page-section">
   <h2>Policies &amp; information</h2>

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe ApplicationController do
     end
   end
 
-  describe 'patron' do
+  describe '#patron' do
     context 'with a logged in user' do
       let(:patron) { Patron.new('fields' => { 'address1' => [], 'standing' => { 'key' => '' } }) }
 
@@ -59,6 +59,24 @@ RSpec.describe ApplicationController do
       it 'is a new instance of the Patron class' do
         expect(controller.patron).to be nil
       end
+    end
+  end
+
+  describe '#patron_or_group' do
+    let(:patron) { Patron.new('fields' => { 'address1' => [], 'standing' => { 'key' => '' } }) }
+
+    before do
+      allow(mock_client).to receive(:patron_info).with('123').and_return(patron)
+      warden.set_user(user)
+    end
+
+    it 'returns the patron' do
+      expect(controller.patron_or_group).to be_an_instance_of Patron
+    end
+
+    it 'returns the group' do
+      controller.params[:group] = true
+      expect(controller.patron_or_group).to be_an_instance_of Group
     end
   end
 end

--- a/spec/controllers/checkouts_controller_spec.rb
+++ b/spec/controllers/checkouts_controller_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe CheckoutsController do
     end
 
     before do
-      allow(mock_patron).to receive(:group_checkouts).and_return(checkouts)
+      allow(mock_patron).to receive(:group).and_return(instance_double(Group, checkouts: checkouts))
       warden.set_user(user)
     end
 

--- a/spec/controllers/fines_controller_spec.rb
+++ b/spec/controllers/fines_controller_spec.rb
@@ -124,8 +124,9 @@ RSpec.describe FinesController do
     end
 
     before do
-      allow(mock_patron).to receive(:group_fines).and_return(fines)
-      allow(mock_patron).to receive(:group_checkouts).and_return(checkouts)
+      allow(mock_patron).to receive(:group).and_return(
+        instance_double(Group, fines: fines, checkouts: checkouts)
+      )
       warden.set_user(user)
     end
 

--- a/spec/controllers/requests_controller_spec.rb
+++ b/spec/controllers/requests_controller_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe RequestsController do
     end
 
     before do
-      allow(mock_patron).to receive(:group_requests).and_return(requests)
+      allow(mock_patron).to receive(:group).and_return(instance_double(Group, requests: requests))
       warden.set_user(user)
     end
 

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -1,0 +1,155 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Group do
+  subject(:group) do
+    described_class.new(
+      {
+        key: '1',
+        fields: fields
+      }.with_indifferent_access
+    )
+  end
+
+  let(:fields) do
+    {
+      firstName: 'Student',
+      lastName: 'Borrower',
+      standing: {
+        key: 'DELINQUENT'
+      },
+      profile: {
+        key: '',
+        fields: {
+          chargeLimit: described_class::CHARGE_LIMIT_THRESHOLD
+        }
+      },
+      groupSettings: {
+        fields: {
+          responsibility: { key: 'PROXY' },
+          group: {
+            fields: {
+              memberList: member_list
+            }
+          }
+        }
+      }
+    }
+  end
+
+  let(:member_list) { [{ key: '521187', fields: {} }] }
+
+  describe '#member_list' do
+    it 'is an array of patrons' do
+      expect(group.member_list).to all(be_a(Patron))
+    end
+    it 'has a patron with a key' do
+      expect(group.member_list.first.key).to eq '521187'
+    end
+    describe 'filtering' do
+      let(:member_list) do
+        [
+          { key: '1', fields: {} },
+          { key: '2', fields: { groupSettings: {
+            fields: {
+              responsibility: {
+                key: 'SPONSOR'
+              }
+            }
+          } } },
+          { key: '3', fields: {} }
+        ]
+      end
+
+      it 'doesn\'t include the sponsor' do
+        expect(group.member_list.select(&:sponsor?)).to eq []
+      end
+      it 'doesn\'t include the currently logged in user' do
+        expect(group.member_list.map(&:key)).not_to include group.key
+      end
+      it 'only has member with key 3' do
+        expect(group.member_list.map(&:key)).to eq ['3']
+      end
+    end
+  end
+
+  describe '#member_names' do
+    let(:member_list) do
+      [
+        { key: '1', fields: {} },
+        { key: '2', fields: { groupSettings: {
+          fields: { responsibility: { key: 'SPONSOR' } }
+        } } },
+        { key: '3', fields: {} },
+        { key: '411612', fields: { firstName: 'Mark (P=Wangchuk)' } }
+      ]
+    end
+
+    it 'returns a name give a patron key' do
+      expect(group.member_name('411612')).to eq 'Wangchuk'
+    end
+  end
+
+  describe '#sponsor' do
+    let(:member_list) do
+      [
+        { key: '1', fields: {} },
+        { key: '2', fields: { groupSettings: {
+          fields: { responsibility: { key: 'SPONSOR' } }
+        } } },
+        { key: '3', fields: {} },
+        { key: '411612', fields: { firstName: 'Mark (P=Wangchuk)' } }
+      ]
+    end
+
+    it 'returns the group sponsor' do
+      expect(group.sponsor).to be_an_instance_of(Patron).and(have_attributes(key: '2'))
+    end
+  end
+
+  describe '#checkouts' do
+    let(:member_list) do
+      [fields: {
+        circRecordList: [
+          key: 1,
+          fields: {}
+        ]
+      }]
+    end
+
+    it 'has checkouts' do
+      expect(group.checkouts).to all(be_a(Checkout))
+    end
+  end
+
+  describe '#fines' do
+    let(:member_list) do
+      [fields: {
+        blockList: [
+          key: 1,
+          fields: {}
+        ]
+      }]
+    end
+
+    it 'has fines' do
+      expect(group.fines).to all(be_a(Fine))
+    end
+  end
+
+  describe '#requests' do
+    let(:member_list) do
+      [fields: {
+        holdRecordList: [
+          key: 1,
+          fields: {}
+        ]
+      }]
+    end
+
+    it 'has fines' do
+      expect(group.requests).to all(be_a(Request))
+    end
+  end
+end

--- a/spec/models/patron_spec.rb
+++ b/spec/models/patron_spec.rb
@@ -236,57 +236,6 @@ RSpec.describe Patron do
       end
     end
 
-    describe 'member_list' do
-      it 'is an array of patrons' do
-        expect(patron.member_list).to all(be_a(described_class))
-      end
-      it 'has a patron with a key' do
-        expect(patron.member_list.first.key).to eq '521187'
-      end
-      describe 'filtering' do
-        let(:member_list) do
-          [
-            { key: '1', fields: {} },
-            { key: '2', fields: { groupSettings: {
-              fields: {
-                responsibility: {
-                  key: 'SPONSOR'
-                }
-              }
-            } } },
-            { key: '3', fields: {} }
-          ]
-        end
-
-        it 'doesn\'t include the sponsor' do
-          expect(patron.member_list.select(&:sponsor?)).to eq []
-        end
-        it 'doesn\'t include the currently logged in user' do
-          expect(patron.member_list.map(&:key)).not_to include patron.key
-        end
-        it 'only has member with key 3' do
-          expect(patron.member_list.map(&:key)).to eq ['3']
-        end
-      end
-    end
-
-    describe '#member_names' do
-      let(:member_list) do
-        [
-          { key: '1', fields: {} },
-          { key: '2', fields: { groupSettings: {
-            fields: { responsibility: { key: 'SPONSOR' } }
-          } } },
-          { key: '3', fields: {} },
-          { key: '411612', fields: { firstName: 'Mark (P=Wangchuk)' } }
-        ]
-      end
-
-      it 'returns a name give a patron key' do
-        expect(patron.member_name('411612')).to eq 'Wangchuk'
-      end
-    end
-
     describe '#group?' do
       context 'when there are group members' do
         let(:member_list) do
@@ -308,51 +257,6 @@ RSpec.describe Patron do
         it 'is not a group when only one member' do
           expect(patron).not_to be_group
         end
-      end
-    end
-
-    describe '#group_checkouts' do
-      let(:member_list) do
-        [fields: {
-          circRecordList: [
-            key: 1,
-            fields: {}
-          ]
-        }]
-      end
-
-      it 'has checkouts' do
-        expect(patron.group_checkouts).to all(be_a(Checkout))
-      end
-    end
-
-    describe '#group_fines' do
-      let(:member_list) do
-        [fields: {
-          blockList: [
-            key: 1,
-            fields: {}
-          ]
-        }]
-      end
-
-      it 'has fines' do
-        expect(patron.group_fines).to all(be_a(Fine))
-      end
-    end
-
-    describe '#group_requests' do
-      let(:member_list) do
-        [fields: {
-          holdRecordList: [
-            key: 1,
-            fields: {}
-          ]
-        }]
-      end
-
-      it 'has fines' do
-        expect(patron.group_requests).to all(be_a(Request))
       end
     end
   end

--- a/spec/views/checkouts/index.html.erb_spec.rb
+++ b/spec/views/checkouts/index.html.erb_spec.rb
@@ -9,12 +9,12 @@ RSpec.describe 'checkouts/index.html.erb' do
     controller.singleton_class.class_eval do
       protected
 
-      def patron; end
-      helper_method :patron
+      def patron_or_group; end
+      helper_method :patron_or_group
     end
 
     stub_template 'shared/_navigation.html.erb' => 'Navigation'
-    allow(view).to receive(:patron).and_return(patron)
+    allow(view).to receive(:patron_or_group).and_return(patron)
 
     assign(:checkouts, [])
   end

--- a/spec/views/summaries/index.html.erb_spec.rb
+++ b/spec/views/summaries/index.html.erb_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe 'summaries/index.html.erb' do
       requests: [],
       fines: [],
       remaining_checkouts: nil,
+      to_partial_path: 'patron/patron',
       **patron_options
     )
   end

--- a/spec/views/summaries/index.html.erb_spec.rb
+++ b/spec/views/summaries/index.html.erb_spec.rb
@@ -26,8 +26,15 @@ RSpec.describe 'summaries/index.html.erb' do
   end
 
   before do
+    controller.singleton_class.class_eval do
+      protected
+
+      def patron_or_group; end
+      helper_method :patron_or_group
+    end
+
     stub_template 'shared/_navigation.html.erb' => 'Navigation'
-    assign(:patron, patron)
+    allow(view).to receive(:patron_or_group).and_return(patron)
   end
 
   context 'when the patron has an expired_date' do


### PR DESCRIPTION
This got a little out of hand with a small refactor to make it easier to show information for the group, but took care of a couple things:

- fixes #239 by showing patron types for sponsors, proxies, and groups
- displaying group/user specific information in the navigation and summary
- DRY'ed up some of the "are we talking about a patron or a group" logic

<img width="506" alt="Screen Shot 2019-07-25 at 09 18 19" src="https://user-images.githubusercontent.com/111218/61890874-45866b80-aebd-11e9-848d-73ded8963e2e.png">
<img width="478" alt="Screen Shot 2019-07-25 at 09 17 56" src="https://user-images.githubusercontent.com/111218/61890880-4919f280-aebd-11e9-956c-c157af923872.png">
