### PR TITLE
Navigation tabs should 'remember' if you're in a group context or not

### DIFF
--- a/app/views/shared/_navigation.html.erb
+++ b/app/views/shared/_navigation.html.erb
@@ -1,14 +1,14 @@
 <nav role="navigation" aria-label="Main navigation" id="mainnav" class="pt-3 pb-3">
   <ul class="nav nav-pills nav-justified container pr-0">
     <li class="nav-item">
-      <%= link_to root_path, class: "nav-link #{active_page_class('summaries')}" do %>
+      <%= link_to summaries_path(group: params[:group]), class: "nav-link #{active_page_class('summaries')}" do %>
         <%= sul_icon :'sharp-person-24px', classes: 'lg' %>
         <span class="label">Summary</span>
         <span class="info"><%= patron.status %></span>
       <% end %>
     </li>
     <li class="nav-item">
-      <%= link_to checkouts_path, class: "nav-link #{active_page_class('checkouts')}" do %>
+      <%= link_to checkouts_path(group: params[:group]), class: "nav-link #{active_page_class('checkouts')}" do %>
         <%= sul_icon :'sharp-playlist_add_check-24px', classes: 'lg' %>
         <span class="label">Checkouts</span>
         <% recalled_count = patron.checkouts.select(&:recalled?).length %>
@@ -23,7 +23,7 @@
       <% end %>
     </li>
     <li class="nav-item">
-      <%= link_to requests_path, class: "nav-link #{active_page_class('requests')}" do %>
+      <%= link_to requests_path(group: params[:group]), class: "nav-link #{active_page_class('requests')}" do %>
         <%= sul_icon :'sharp-access_time-24px', classes: 'lg' %>
         <span class="label">Requests</span>
         <% pickup_count = patron.requests.select(&:ready_for_pickup?).length %>
@@ -35,7 +35,7 @@
       <% end %>
     </li>
     <li class="nav-item">
-      <%= link_to fines_path, class: "nav-link #{active_page_class('fines')}" do %>
+      <%= link_to fines_path(group: params[:group]), class: "nav-link #{active_page_class('fines')}" do %>
         <%= sul_icon :'sharp-attach_money-24px', classes: 'lg' %>
         <span class="label">Fines</span>
         <% owed = patron.fines.sum(&:owed) %>

--- a/spec/features/navigation_spec.rb
+++ b/spec/features/navigation_spec.rb
@@ -192,4 +192,32 @@ RSpec.describe 'Navigation', type: :feature do
       expect(page).to have_css('.nav-link', text: 'Fines $100.00')
     end
   end
+
+  context 'with a group' do
+    before do
+      # Un-stub the symphony client so we hit our fixture data endpoint
+      allow(SymphonyClient).to receive(:new).and_call_original
+
+      login_as(username: 'PROXY21', patron_key: '521197')
+    end
+
+    it 'preserves the group parameter across navigation' do
+      visit summaries_path
+
+      click_link 'Group'
+      expect(page).to have_css('.nav-link.active', text: 'Group')
+
+      click_link 'Requests'
+      expect(page).to have_css('.nav-link.active', text: 'Group')
+
+      click_link 'Checkouts'
+      expect(page).to have_css('.nav-link.active', text: 'Group')
+
+      click_link 'Fines'
+      expect(page).to have_css('.nav-link.active', text: 'Group')
+
+      click_link 'Summary'
+      expect(page).to have_css('.nav-link.active', text: 'Group')
+    end
+  end
 end


### PR DESCRIPTION
After selecting a groups tab, navigation links should keep the user in the group context.

![2019-07-25 08-23-08 2019-07-25 08_23_58](https://user-images.githubusercontent.com/111218/61887003-9b571580-aeb5-11e9-9e64-78dc0aad8f28.gif)
