### PR TITLE
Add eResource access message for library_id logged in users, fixes #214

### DIFF
--- a/app/views/patron/_patron.html.erb
+++ b/app/views/patron/_patron.html.erb
@@ -12,7 +12,7 @@
   <% end %>
   <% if patron.fee_borrower? %>
     <dt class="col-4 col-md-2 font-weight-normal">eResource access:</dt>
-    <dd class="col-10 col-sm-11 patron-status">In-library only</dd>
+    <dd class="col-8 col-md-10 patron-status">In-library only</dd>
   <% end %>
   <% if patron.expired_date && (patron.fee_borrower? || patron.proxy_borrower?) %>
     <dt class="col-2 col-sm-1 font-weight-normal">Privileges expire:</dt>

--- a/app/views/patron/_patron.html.erb
+++ b/app/views/patron/_patron.html.erb
@@ -11,7 +11,7 @@
     <dd class="col-10 col-sm-11 patron-status"><%= pluralize(patron.borrow_limit, 'checkout') %></dd>
   <% end %>
   <% if patron.fee_borrower? %>
-    <dt class="col-2 col-sm-1 font-weight-normal">eResource access:</dt>
+    <dt class="col-4 col-md-2 font-weight-normal">eResource access:</dt>
     <dd class="col-10 col-sm-11 patron-status">In-library only</dd>
   <% end %>
   <% if patron.expired_date && (patron.fee_borrower? || patron.proxy_borrower?) %>

--- a/app/views/patron/_patron.html.erb
+++ b/app/views/patron/_patron.html.erb
@@ -10,6 +10,10 @@
     <dt class="col-2 col-sm-1 font-weight-normal">Borrower limit:</dt>
     <dd class="col-10 col-sm-11 patron-status"><%= pluralize(patron.borrow_limit, 'checkout') %></dd>
   <% end %>
+  <% if patron.fee_borrower? %>
+    <dt class="col-2 col-sm-1 font-weight-normal">eResource access:</dt>
+    <dd class="col-10 col-sm-11 patron-status">In-library only</dd>
+  <% end %>
   <% if patron.expired_date && (patron.fee_borrower? || patron.proxy_borrower?) %>
     <dt class="col-2 col-sm-1 font-weight-normal">Privileges expire:</dt>
     <dd class="col-10 col-sm-11 expired-date"><%= l(patron.expired_date, format: :short) %></dd>

--- a/spec/views/summaries/index.html.erb_spec.rb
+++ b/spec/views/summaries/index.html.erb_spec.rb
@@ -30,6 +30,7 @@ RSpec.describe 'summaries/index.html.erb' do
       protected
 
       def patron_or_group; end
+
       helper_method :patron_or_group
     end
 
@@ -56,6 +57,11 @@ RSpec.describe 'summaries/index.html.erb' do
       render
 
       expect(rendered).not_to have_css('dt', text: 'Privileges expire')
+    end
+    it 'renders eResource access restriction' do
+      render
+
+      expect(rendered).to have_css 'dt', text: 'eResource access:'
     end
   end
 end


### PR DESCRIPTION
This could have been implemented using the existing `shibboleth?` method, but would not work in local development. I've implemented the `library_id_user` to reduce developer confusion.

![Screen Shot 2019-07-25 at 2 30 57 PM](https://user-images.githubusercontent.com/1656824/61906557-d7f03480-aee8-11e9-8040-62dbf7b1ece0.png)

We may also want to adjust markup here (column lengths) but thought that might want to be deferred once we get all of the information needed here.