### PR TITLE
Implement custom contact form

### DIFF
--- a/app/assets/javascripts/modal.js
+++ b/app/assets/javascripts/modal.js
@@ -1,0 +1,60 @@
+// Adapted from https://github.com/projectblacklight/blacklight/blob/master/app/javascript/blacklight/modal.js
+
+Mylibrary = {};
+
+if (Mylibrary.modal === undefined) {
+  Mylibrary.modal = {};
+}
+
+Mylibrary.modal.modalSelector = '#mylibrary-modal';
+Mylibrary.modal.containerSelector    = '[data-mylibrary-modal~=container]';
+Mylibrary.modal.modalCloseSelector   = '[data-mylibrary-modal~=close]';
+
+Mylibrary.modal.modalAjaxClickLink = function(e) {
+  e.preventDefault();
+  
+  $.ajax({
+    url: $(this).attr('href')
+  })
+  .fail(Mylibrary.modal.onFailure)
+  .done(Mylibrary.modal.receiveAjax)
+}
+
+// Called on fatal failure of ajax load, function returns content
+// to show to user in modal.  Right now called only for extreme
+// network errors.
+Mylibrary.modal.onFailure = function(data) {
+  var contents =  '<div class="modal-header">' +
+            '<div class="modal-title">Network Error</div>' +
+            '<button type="button" class="mylibrary-modal-close close" data-dismiss="modal" aria-label="Close">' +
+            '  <span aria-hidden="true">&times;</span>' +
+            '</button>';
+  $(Mylibrary.modal.modalSelector).find('.modal-content').html(contents);
+  $(Mylibrary.modal.modalSelector).modal('show');
+}
+
+Mylibrary.modal.receiveAjax = function (contents) {
+  // does it have a data- selector for container?
+  // important we don't execute script tags, we shouldn't.
+  // code modelled off of JQuery ajax.load. https://github.com/jquery/jquery/blob/master/src/ajax/load.js?source=c#L62
+  var container =  $('<div>').
+    append( jQuery.parseHTML(contents) ).find( Mylibrary.modal.containerSelector ).first();
+  if (container.length !== 0) {
+    contents = container.html();
+  }
+  console.log(contents);
+
+  $(Mylibrary.modal.modalSelector).find('.modal-content').html(contents);
+
+  // send custom event with the modal dialog div as the target
+  var e    = $.Event('loaded.mylibrary.mylibrary-modal')
+  $(Mylibrary.modal.modalSelector).trigger(e);
+  // if they did preventDefault, don't show the dialog
+  if (e.isDefaultPrevented()) return;
+
+  $(Mylibrary.modal.modalSelector).modal('show');
+};
+
+$(document).on('turbolinks:load', function(){
+  $('body').on('click', 'a[data-mylibrary-modal~=trigger]', Mylibrary.modal.modalAjaxClickLink);
+});

--- a/app/controllers/contact_forms_controller.rb
+++ b/app/controllers/contact_forms_controller.rb
@@ -2,7 +2,13 @@
 
 # Controller for Contct forms
 class ContactFormsController < ApplicationController
-  def new; end
+  def new
+    respond_to do |format|
+      format.html do
+        return render layout: false if request.xhr?
+      end
+    end
+  end
 
   def create
     return unless request.post?

--- a/app/controllers/contact_forms_controller.rb
+++ b/app/controllers/contact_forms_controller.rb
@@ -2,6 +2,8 @@
 
 # Controller for Contct forms
 class ContactFormsController < ApplicationController
+  before_action :authenticate_user!
+
   def new
     respond_to do |format|
       format.html do

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -33,4 +33,8 @@ module ApplicationHelper
   def library_name(code)
     Mylibrary::Application.config.library_map[code] || code
   end
+
+  def library_email(code)
+    Mylibrary::Application.config.library_contact[code] || Settings.ACCESS_SERVICES_EMAIL
+  end
 end

--- a/app/helpers/contact_forms_helper.rb
+++ b/app/helpers/contact_forms_helper.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# ContactFormsHelper
+module ContactFormsHelper
+  def contact_form_to(code = nil)
+    label = ['Access Services']
+    label[0] = library_name(code) if code
+    label << ' ('
+    label << link_to(library_email(code), "mailto:#{library_email(code)}")
+    label << ')'
+    safe_join(label, '')
+  end
+end

--- a/app/mailers/contact_mailer.rb
+++ b/app/mailers/contact_mailer.rb
@@ -8,7 +8,7 @@ class ContactMailer < ActionMailer::Base
     @message = params[:message]
     @ip = ip
 
-    mail(to: Settings.ACCESS_SERVICES_EMAIL,
+    mail(to: params[:contact_form_to],
          subject: 'Access Services Question/Comment from My Library App',
          from: 'contact@mylibrary.stanford.edu',
          reply_to: params[:email])

--- a/app/views/contact_forms/new.html.erb
+++ b/app/views/contact_forms/new.html.erb
@@ -1,0 +1,1 @@
+<%= render 'shared/contact_forms/form' %>

--- a/app/views/fines/_fine.html.erb
+++ b/app/views/fines/_fine.html.erb
@@ -35,6 +35,14 @@
       <dt class="col-3 offset-1 col-md-2 offset-md-2">Source:</dt>
       <dd class="col-8"><%= library_name fine.library %></dd>
     </dl>
+    <div class="row">
+      <div class="col-11 offset-1 col-md-10 offset-md-2">
+        <%= link_to contact_path(library: fine.library), data: { 'mylibrary-modal' => 'trigger' } do %>
+          <%= sul_icon 'sharp-email-24px' %>
+          Contact library
+        <% end %>
+      </div>
+    </div>
 
     <%= detail_link_to_searchworks(fine.catkey) if fine.bib? %>
   </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -29,6 +29,6 @@
     </div> <!-- #su-wrap end -->
     <%= render '/shared/sul_footer' %>
     <%= render '/shared/global_footer' %>
-
+    <%= render partial: 'shared/modal' %>
   </body>
 </html>

--- a/app/views/shared/_header_navbar.html.erb
+++ b/app/views/shared/_header_navbar.html.erb
@@ -3,7 +3,7 @@
     <%= link_to 'My Library Account', root_path, class: 'navbar-brand font-weight-light py-3' %>
     <div class="topnav-links">
       <% if current_user? %>
-        <%= link_to contact_path, class: 'navbar-link', 'data-toggle' =>  'modal', 'data-target' => '#contact-modal-window' do %>
+        <%= link_to contact_path, class: 'navbar-link', data: { 'mylibrary-modal' => 'trigger' } do %>
           <%= sul_icon :'sharp-email-24px' %> Contact Access Services
         <% end %>
         <%= link_to 'tel:+16507231493', class: 'navbar-link' do %>
@@ -13,13 +13,3 @@
     </div>
   </div>
 </div>
-
-<% if current_user? %>
-  <div class="modal fade" id="contact-modal-window" tabindex="-1" role="dialog" aria-labelledby="contactForm" aria-hidden="true">
-    <div class="modal-dialog" role="document">
-      <div class="modal-content">
-        <%= render 'shared/contact_forms/form' %>
-      </div>
-    </div>
-  </div>
-<% end %>

--- a/app/views/shared/_modal.html.erb
+++ b/app/views/shared/_modal.html.erb
@@ -1,0 +1,6 @@
+<div id="mylibrary-modal" class="modal fade" tabindex="-1" role="dialog" aria-hidden="true">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+    </div>
+  </div>
+</div>

--- a/app/views/shared/contact_forms/_form.html.erb
+++ b/app/views/shared/contact_forms/_form.html.erb
@@ -3,6 +3,7 @@
 </div>
 <div class="modal-body">
   <%= form_tag contact_path, method: :post, class: 'contact-form', role: 'form' do %>
+    <%= hidden_field_tag :contact_form_to, library_email(params[:library]) %>
     <dl class="row">
       <dt class="col-2">Source:<dt>
       <dd class="col-10 reporting-from-field"><%= request.referer %></dd>
@@ -10,7 +11,7 @@
       <dt class="col-2">From:<dt>
       <dd class="col-10"><%= patron.display_name %></dd>
       <dt class="col-2">To:<dt>
-      <dd class="col-10">Access Services (<%= link_to Settings.ACCESS_SERVICES_EMAIL, "mailto:#{Settings.ACCESS_SERVICES_EMAIL}" %>)</dd>
+      <dd class="col-10"><%= contact_form_to(params[:library]) %></dd>
     </dl>
     <div class="row">
       <div class="col-12 mt-3 mb-3">

--- a/config/application.rb
+++ b/config/application.rb
@@ -38,6 +38,36 @@ module Mylibrary
       manager.default_strategies :shibboleth
     end
 
+    config.library_contact = {
+      'ARS' => 'soundarchive@stanford.edu',
+      'ART' => 'artlibrary@stanford.edu',
+      'BIOLOGY' => 'greencirc@stanford.edu',
+      'BUSINESS' => 'library@gsb.stanford.edu',
+      'CHEMCHMENG' => 'greencirc@stanford.edu',
+      'CLASSICS' => 'classics@stanford.edu',
+      'EARTH-SCI' => 'brannerlibrary@stanford.edu',
+      'EAST-ASIA' => 'eastasialibrary@stanford.edu',
+      'EDUCATION' => 'cubberley@stanford.edu',
+      'ENG' => 'englibrary@stanford.edu',
+      'GREEN' => 'greencirc@stanford.edu',
+      'HOOVER' => 'hoover-library-archives@stanford.edu',
+      'HOPKINS' => 'HMS-Library@lists.stanford.edu',
+      'HV-ARCHIVE' => 'hoover-library-archives@stanford.edu',
+      'LANE-MED' => 'laneaskus@stanford.edu',
+      'LATHROP' => 'greencirc@stanford.edu',
+      'LAW' => 'reference@law.stanford.edu',
+      'MATH-CS' => 'greencirc@stanford.edu',
+      'MEDIA-MTXT' => 'greencirc@stanford.edu',
+      'MUSIC' => 'muslibcirc@stanford.edu',
+      'RUMSEYMAP' => 'rumseymapcenter@stanford.edu',
+      'SAL' => 'salcirculation@stanford.edu',
+      'SAL3' => 'greencirc@stanford.edu',
+      'SAL-NEWARK' => 'greencirc@stanford.edu',
+      'SCIENCE' => 'sciencelibrary@stanford.edu',
+      'SPEC-COLL' => 'specialcollections@stanford.edu',
+      'TANNER' => 'tanner-library@stanford.edu'
+    }
+
     config.library_map = {
       'ARS' => 'Archive of Recorded Sound',
       'ART' => 'Art & Architecture Library (Bowes)',

--- a/spec/controllers/contact_forms_controller_spec.rb
+++ b/spec/controllers/contact_forms_controller_spec.rb
@@ -9,22 +9,26 @@ RSpec.describe ContactFormsController, type: :controller do
       patron_info: { 'fields' => { 'address1' => [], 'standing' => { 'key' => '' } } }
     )
   end
+  let(:user) do
+    { username: 'somesunetid', 'patronKey' => '123' }
+  end
+
+  before do
+    allow(SymphonyClient).to receive(:new).and_return(mock_client)
+    login_as(username: 'stub_user')
+    warden.set_user(user)
+    headers = { HTTP_REFERER: root_path }
+    request.headers.merge! headers
+  end
 
   describe 'creating a message to contact Access Services' do
-    before do
-      allow(SymphonyClient).to receive(:new).and_return(mock_client)
-      login_as(username: 'stub_user')
-      warden.set_user(user)
-      headers = { HTTP_REFERER: root_path }
-      request.headers.merge! headers
-    end
-
-    let(:user) do
-      { username: 'somesunetid', 'patronKey' => '123' }
-    end
-
     it 'returns html success' do
-      post :create, params: { message: 'Hello pooftah', email: 'test@test.mail', url: '/summaries' }
+      post :create, params: {
+        message: 'Hello pooftah',
+        email: 'test@test.mail',
+        url: '/summaries',
+        contact_form_to: 'greencirc@stanford.edu'
+      }
       expect(flash[:success]).to eq 'Thank you! Someone from Access Services will be in touch with you soon.'
     end
   end

--- a/spec/features/contact_form_spec.rb
+++ b/spec/features/contact_form_spec.rb
@@ -11,8 +11,14 @@ RSpec.describe 'Contact form', type: :feature do
 
     describe 'hidden', js: true do
       it 'form should be hidden' do
-        expect(page).not_to have_css('.contact-form', visible: true)
+        expect(page).not_to have_css('#mylibrary-modal', visible: true)
       end
+    end
+
+    it 'can have custom library contact information' do
+      visit contact_path(library: 'EARTH-SCI')
+
+      expect(page).to have_css 'dd', text: 'Earth Sciences Library (Branner) (brannerlibrary@stanford.edu)'
     end
 
     describe 'visible', js: true do
@@ -21,12 +27,11 @@ RSpec.describe 'Contact form', type: :feature do
       end
 
       it 'is shown' do
-        expect(page).to have_css('#contact-modal-window', visible: true)
-        page.save_screenshot('screen.png')
+        expect(page).to have_css('#contactForm', visible: true)
       end
 
       it 'has a Cancel link' do
-        expect(page).to have_css('.contact-form button', text: 'Cancel')
+        expect(page).to have_css('.contact-form a', text: 'Cancel')
       end
 
       it 'has a Send button' do

--- a/spec/features/fines_spec.rb
+++ b/spec/features/fines_spec.rb
@@ -31,6 +31,7 @@ RSpec.describe 'Fines Page', type: :feature do
         expect(page).to have_css('li', count: 1)
         expect(page).to have_css('li h3', text: 'Research handbook on the law of virtual and augmented reality')
         expect(page).to have_css('li .status', text: 'Damaged item')
+        expect(page).to have_css('li a', text: 'Contact library')
       end
     end
 

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -41,4 +41,14 @@ RSpec.describe ApplicationHelper do
       expect(helper.library_name('NOSUCHLIBRARY')).to eq 'NOSUCHLIBRARY'
     end
   end
+
+  describe '#library_email' do
+    it 'translates the code to a an email' do
+      expect(helper.library_email('EARTH-SCI')).to eq 'brannerlibrary@stanford.edu'
+    end
+
+    it 'falls back to greencirc' do
+      expect(helper.library_email('NOSUCHLIBRARY')).to eq 'greencirc@stanford.edu'
+    end
+  end
 end

--- a/spec/helpers/contact_forms_helper_spec.rb
+++ b/spec/helpers/contact_forms_helper_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ContactFormsHelper do
+  describe '#contact_form_to' do
+    context 'when code is not provided' do
+      it 'creates a default contact' do
+        expect(helper.contact_form_to).to eq 'Access Services '\
+          '(<a href="mailto:greencirc@stanford.edu">greencirc@stanford.edu</a>)'
+      end
+    end
+
+    context 'when code is provided' do
+      it 'creates a custom contact' do
+        expect(helper.contact_form_to('EARTH-SCI')).to eq 'Earth Sciences Library (Branner) '\
+          '(<a href="mailto:brannerlibrary@stanford.edu">brannerlibrary@stanford.edu</a>)'
+      end
+    end
+  end
+end

--- a/spec/mailers/contact_mailer_spec.rb
+++ b/spec/mailers/contact_mailer_spec.rb
@@ -9,7 +9,8 @@ RSpec.describe ContactMailer do
       let(:params) do
         {
           name: 'Daenerys Targaryen',
-          email: 'dtarg@westeros.org'
+          email: 'dtarg@westeros.org',
+          contact_form_to: 'greencirc@stanford.edu'
         }
       end
       let(:mail) { described_class.submit_feedback(params, ip) }


### PR DESCRIPTION
Fixes #37 

The JavaScript is mostly ported from Blacklight and how it does its nice configurable modals. This will enable #242 very easily
![contactcustom](https://user-images.githubusercontent.com/1656824/61916152-98374600-af04-11e9-940f-129d8619cb56.gif)
