### PR TITLE
Format a date as 'human readable' by showing today/yesterday/tomorrow…

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -5,6 +5,29 @@ module ApplicationHelper
     'active' if controller_name == name
   end
 
+  # Return a nice, human-readable date (for e.g. a due date or request deadline)
+  # For short-term loans, also include the time.
+  def today_with_time_or_date(date, short_term: false)
+    return l(date, format: :time_today) if short_term && date.today?
+
+    format_human_readable_date(date)
+  end
+
+  # Format a date as 'human readable' by showing today/yesterday/tomorrow,
+  # as appropriate, and otherwise falling back on an actual date display
+  def format_human_readable_date(date)
+    case date.to_date
+    when Time.zone.today.to_date
+      'Today'
+    when Time.zone.tomorrow
+      'Tomorrow'
+    when Time.zone.yesterday
+      'Yesterday'
+    else
+      l(date, format: :short)
+    end
+  end
+
   # Wrap a link to the SearchWorks record for the given Catkey wrapped in the markup
   # necessary to be aligned with the content in the collapsible list sections
   def detail_link_to_searchworks(catkey)

--- a/app/helpers/checkouts_helper.rb
+++ b/app/helpers/checkouts_helper.rb
@@ -10,13 +10,6 @@ module CheckoutsHelper
     end
   end
 
-  def today_with_time_or_date(date, short_term: false)
-    return l(date, format: :short) unless short_term
-    return l(date, format: :short) unless date.today?
-
-    l(date, format: :time_today)
-  end
-
   def time_remaining_for_checkout(checkout)
     return pluralize(checkout.days_remaining, 'day') unless checkout.short_term_loan?
 

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -13,6 +13,45 @@ RSpec.describe ApplicationHelper do
     end
   end
 
+  describe '#today_with_time_or_date' do
+    context 'when the checkout is a short term loan' do
+      it 'returns a string that says Today and the time' do
+        expect(helper.today_with_time_or_date(Time.zone.now + 42.minutes, short_term: true))
+          .to match(/^Today at\s{1,2}\d/)
+      end
+
+      context 'when the due date is on a past date' do
+        it 'returns a formatted date' do
+          expect(
+            helper.today_with_time_or_date(Time.zone.parse('2019-01-01'), short_term: true)
+          ).to eq 'January  1, 2019'
+        end
+      end
+    end
+
+    it 'returns a formatted date' do
+      expect(helper.today_with_time_or_date(Time.zone.parse('2019-01-01'))).to eq 'January  1, 2019'
+    end
+
+    context 'with a time from today' do
+      it 'returns "Today"' do
+        expect(helper.today_with_time_or_date(Time.zone.now)).to eq 'Today'
+      end
+    end
+
+    context 'with a time from tomorrow' do
+      it 'returns "Tomorrow"' do
+        expect(helper.today_with_time_or_date(Time.zone.now + 1.day)).to eq 'Tomorrow'
+      end
+    end
+
+    context 'with a time from yesterday' do
+      it 'returns "Yesterday"' do
+        expect(helper.today_with_time_or_date(Time.zone.now - 1.day)).to eq 'Yesterday'
+      end
+    end
+  end
+
   describe '#detail_link_to_searchworks' do
     let(:content) { Capybara.string(helper.detail_link_to_searchworks('12345')) }
 

--- a/spec/helpers/checkouts_helper_spec.rb
+++ b/spec/helpers/checkouts_helper_spec.rb
@@ -39,29 +39,6 @@ RSpec.describe CheckoutsHelper do
     end
   end
 
-  describe '#today_with_time_or_date' do
-    context 'when the checkout is a short term loan' do
-      it 'returns a string that says Today and the time' do
-        expect(helper.today_with_time_or_date(Time.zone.now + 42.minutes, short_term: true))
-          .to match(/^Today at\s{1,2}\d/)
-      end
-
-      context 'when the due date is on a past date' do
-        it 'returns a formatted date' do
-          expect(
-            helper.today_with_time_or_date(Time.zone.parse('2019-01-01'), short_term: true)
-          ).to eq 'January  1, 2019'
-        end
-      end
-    end
-
-    context 'when the short term flag is false' do
-      it 'returns a formatted date' do
-        expect(helper.today_with_time_or_date(Time.zone.parse('2019-01-01'))).to eq 'January  1, 2019'
-      end
-    end
-  end
-
   describe '#render_checkout_status' do
     let(:checkout) do
       instance_double(


### PR DESCRIPTION
…, as appropriate; fixes #264