### PR TITLE
Show the collapses when javascript is not available

### DIFF
--- a/app/assets/stylesheets/nojs.scss
+++ b/app/assets/stylesheets/nojs.scss
@@ -1,0 +1,7 @@
+.collapse {
+  &:not(.show) {
+    &:not(.feedback-form-container) {
+      display: block;
+    }
+  }
+}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,6 +13,9 @@
     <link href='https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,700' rel='stylesheet' type='text/css'>
 
     <%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>
+    <noscript>
+      <%= stylesheet_link_tag 'nojs', media: 'all' %>
+    </noscript>
   </head>
 
   <body>

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -13,4 +13,4 @@ Rails.application.config.assets.paths << Rails.root.join('node_modules')
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in the app/assets
 # folder are already added.
-# Rails.application.config.assets.precompile += %w( admin.js admin.css )
+Rails.application.config.assets.precompile += %w[nojs.css]


### PR DESCRIPTION
Fixes #283 

Loads a special stylesheet for nojs views (showing the collapses that aren't the feedback form)

![Screen Shot 2019-07-26 at 5 18 59 PM](https://user-images.githubusercontent.com/1656824/61986019-971c1c80-afc9-11e9-8a56-82e69702f48b.png)
