### PR TITLE
Add initial support for displaying active BorrowDirect requests in requests tab

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,6 +46,8 @@ gem 'warden'
 
 gem 'nokogiri'
 
+gem 'borrow_direct'
+
 group :production do
   gem 'mysql2', '~> 0.5'
   gem 'newrelic_rpm'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -57,6 +57,8 @@ GEM
       autoprefixer-rails (>= 9.1.0)
       popper_js (>= 1.14.3, < 2)
       sassc-rails (>= 2.0.0)
+    borrow_direct (1.2.0)
+      httpclient (~> 2.4)
     builder (3.2.3)
     bundler-audit (0.6.1)
       bundler (>= 1.2.0, < 3)
@@ -155,6 +157,7 @@ GEM
       domain_name (~> 0.5)
     http-form_data (2.1.1)
     http_parser.rb (0.6.0)
+    httpclient (2.8.3)
     i18n (1.6.0)
       concurrent-ruby (~> 1.0)
     jaro_winkler (1.5.3)
@@ -365,6 +368,7 @@ PLATFORMS
 DEPENDENCIES
   bootsnap (>= 1.1.0)
   bootstrap (~> 4.3)
+  borrow_direct
   byebug
   capistrano (~> 3.0)
   capistrano-passenger

--- a/app/models/borrow_direct_requests.rb
+++ b/app/models/borrow_direct_requests.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+##
+# Wrap the BorrowDirect::RequestQuery in a class that we
+# can inject our patron barcode from (and do error handling)
+class BorrowDirectRequests
+  attr_reader :patron
+  def initialize(patron)
+    @patron = patron
+  end
+
+  def requests
+    request_client.requests('open', true).map { |request| BorrowDirectRequests::Request.new(request) }.select(&:active?)
+  rescue BorrowDirect::Error
+    []
+  end
+
+  private
+
+  def request_client
+    @request_client ||= BorrowDirect::RequestQuery.new(patron.barcode)
+  end
+
+  ##
+  # Wrap the BorrowDirect::RequestQuery::Item in a class
+  # so we can give it a similar iterface to Symphony Requests
+  class Request < SimpleDelegator
+    # Request becomes ON_LOAN once we receive it (and should show as a request ready for pickup/checkout)
+    # Request becomes COMPLETED once the uesr returns it
+    ACTIVE_REQUEST_STATUSES = %w[
+      ENTERED IN_PROCESS SHIPPED
+    ].freeze
+
+    def active?
+      ACTIVE_REQUEST_STATUSES.include? request_status
+    end
+
+    def key
+      request_number
+    end
+
+    def expiration_date; end
+
+    def fill_by_date; end
+
+    def ready_for_pickup?
+      false
+    end
+
+    def to_partial_path
+      'requests/borrow_direct_request'
+    end
+  end
+end

--- a/app/models/patron.rb
+++ b/app/models/patron.rb
@@ -134,7 +134,7 @@ class Patron
   end
 
   def requests
-    @requests ||= fields['holdRecordList'].map { |request| Request.new(request) }
+    @requests ||= symphony_requests + borrow_direct_requests
   end
 
   def group
@@ -150,6 +150,16 @@ class Patron
   end
 
   private
+
+  def borrow_direct_requests
+    return [] if proxy_borrower? # Proxies can't submit borrow direct requests, so don't check.
+
+    BorrowDirectRequests.new(self).requests
+  end
+
+  def symphony_requests
+    fields['holdRecordList'].map { |request| Request.new(request) }
+  end
 
   def fields
     record['fields']

--- a/app/views/requests/_borrow_direct_request.html.erb
+++ b/app/views/requests/_borrow_direct_request.html.erb
@@ -1,0 +1,31 @@
+<li class="row d-flex flex-wrap list-group-item">
+  <div class="d-flex flex-row flex-grow-1 justify-content-between w-100 row col-md-4">
+    <div class="w-50 col-md-6 library">
+      <span class="d-md-none">Deliver to </span> Stanford
+    </div>
+    <div class="w-50 col-md-6 text-right text-md-left date">
+      In transit
+    </div>
+  </div>
+  <div class="d-flex flex-grow-1 flex-column flex-md-row w-75 row col-md-8">
+    <h3 class="col-md-7 clamp-2 record-title title text-reset"><%= borrow_direct_request.title %></h3>
+    <div class="d-flex flex-row row col-md-5">
+      <div class="w-50 col-md-6"></div>
+      <div class="w-50 col-md-6"></div>
+    </div>
+  </div>
+  <div>
+    <button class="btn collapsed" type="button" data-toggle="collapse" data-target="#collapseRequest-<%= borrow_direct_request.key %>" aria-expanded="false" aria-controls="collapseRequest-<%= borrow_direct_request.key %>">
+      <span class="expand-icon"><%= sul_icon :'sharp-add-24px' %><span class="sr-only">Expand</span></span>
+      <span class="collapse-icon"><%= sul_icon :'sharp-remove-24px' %><span class="sr-only">Collapse</span></span>
+    </button>
+  </div>
+  <div class="collapse w-100" id="collapseRequest-<%= borrow_direct_request.key %>">
+    <dl class="row mb-0">
+      <dt class="col-3 offset-1 col-md-2 offset-md-2">Requested:</dt>
+      <dd class="col-8"><%= l(borrow_direct_request.date_submitted, format: :short) %></dd>
+      <dt class="col-3 offset-1 col-md-2 offset-md-2">Source:</dt>
+      <dd class="col-8">BorrowDirect</dd>
+    </dl>
+  </div>
+</li>

--- a/config/initializers/borrow_direct.rb
+++ b/config/initializers/borrow_direct.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+BorrowDirect::Defaults.api_key = Settings.borrow_direct.api_key
+
+BorrowDirect::Defaults.library_symbol = 'STANFORD'
+
+BorrowDirect::Defaults.api_base = BorrowDirect::Defaults::PRODUCTION_API_BASE if Rails.env.production?

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,4 +1,6 @@
 GOOGLE_ANALYTICS_ID:
+borrow_direct:
+  api_key: ''
 symws:
   url:
   headers: {}

--- a/spec/models/borrow_direct_requests_spec.rb
+++ b/spec/models/borrow_direct_requests_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe BorrowDirectRequests do
+  subject(:bd_requests) { described_class.new(patron) }
+
+  let(:patron) { instance_double(Patron, barcode: '123456') }
+  let(:in_process_request) do
+    instance_double(
+      BorrowDirect::RequestQuery::Item,
+      request_number: 'STA-123454321',
+      request_status: 'IN_PROCESS',
+      date_submitted: Time.zone.today - 3.days
+    )
+  end
+  let(:completed_request) { instance_double(BorrowDirect::RequestQuery::Item, request_status: 'COMPLETED') }
+  let(:mock_requests) do
+    instance_double(BorrowDirect::RequestQuery, requests: [in_process_request, completed_request])
+  end
+
+  context 'when successful' do
+    before do
+      allow(BorrowDirect::RequestQuery).to receive(:new).with(patron.barcode).and_return(mock_requests)
+    end
+
+    it 'only return requests with active statuses' do
+      expect(bd_requests.requests.length).to be(1)
+    end
+  end
+
+  context 'when borrow direct returns an error' do
+    before do
+      allow(BorrowDirect::RequestQuery).to receive(:new).with(patron.barcode).and_raise(
+        BorrowDirect::Error, 'Item not Found'
+      )
+    end
+
+    it 'returns an empty array' do
+      expect(bd_requests.requests).to eq([])
+    end
+  end
+
+  describe 'BorrowDirectRequests::Request' do
+    let(:request) do
+      BorrowDirectRequests::Request.new(in_process_request)
+    end
+
+    it 'delegates methods to the given request oboject' do
+      expect(request.date_submitted).to eq in_process_request.date_submitted
+    end
+
+    it 'returns the request_number as the key' do
+      expect(request.key).to eq in_process_request.request_number
+    end
+
+    it { expect(request).not_to be_ready_for_pickup }
+
+    context 'when in an active state' do
+      it { expect(request).to be_active }
+    end
+
+    context 'when not in an active state' do
+      let(:request) do
+        BorrowDirectRequests::Request.new(completed_request)
+      end
+
+      it { expect(request).not_to be_active }
+    end
+  end
+end

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -203,8 +203,18 @@ RSpec.describe Group do
       }]
     end
 
-    it 'has fines' do
-      expect(group.requests).to all(be_a(Request))
+    before do
+      allow(BorrowDirectRequests).to receive(:new).and_return(
+        instance_double(BorrowDirectRequests, requests: [{ key: 2 }])
+      )
+    end
+
+    it 'has checkouts from symphony' do
+      expect(group.requests.first).to be_a(Request)
+    end
+
+    it 'has checkouts from BorrowDirect' do
+      expect(group.requests.last[:key]).to be(2)
     end
   end
 end

--- a/spec/models/patron_spec.rb
+++ b/spec/models/patron_spec.rb
@@ -334,11 +334,18 @@ RSpec.describe Patron do
   context 'with requests' do
     before do
       fields[:holdRecordList] = [{ key: 1, fields: {} }]
+      allow(BorrowDirectRequests).to receive(:new).and_return(
+        instance_double(BorrowDirectRequests, requests: [{ key: 2 }])
+      )
     end
 
     describe '#requests' do
       it 'returns a list of requests for the patron' do
         expect(patron.requests).to include a_kind_of(Request).and(have_attributes(key: 1))
+      end
+
+      it 'includes requests that come from the BorrowDirectRequests class' do
+        expect(patron.requests.last[:key]).to be 2
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -103,5 +103,6 @@ RSpec.configure do |config|
   # Mock all requests to symphony for feature tests
   config.before type: :feature do
     stub_request(:any, %r{example.com/symws}).to_rack(FakeSymphony)
+    stub_request(:any, /rc\.relais-host\.com/).to_return(status: 200)
   end
 end


### PR DESCRIPTION
Closes #212 

## Mobile
<img width="485" alt="Screen Shot 2019-07-26 at 4 40 47 PM" src="https://user-images.githubusercontent.com/96776/61986476-2b838080-afc4-11e9-9142-e000faf002ec.png">

## Desktop
<img width="1151" alt="Screen Shot 2019-07-26 at 4 38 19 PM" src="https://user-images.githubusercontent.com/96776/61986453-0abb2b00-afc4-11e9-861b-d2925366c663.png">

