### PR TITLE
Improve performance for users with tons of checkouts

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -16,7 +16,7 @@ class ApplicationController < ActionController::Base
   def patron
     return unless current_user?
 
-    @patron ||= Patron.new(symphony_client.patron_info(current_user.patron_key))
+    @patron ||= Patron.new(patron_info_response)
   end
 
   def patron_or_group
@@ -39,11 +39,19 @@ class ApplicationController < ActionController::Base
     @symphony_legacy_client ||= SymphonyLegacyClient.new
   end
 
+  def patron_info_response
+    symphony_client.patron_info(current_user.patron_key, item_details: item_details)
+  end
+
   def authenticate_user!
     redirect_to root_url unless current_user?
   end
 
   def logout_user!
     redirect_to logout_path if current_user?
+  end
+
+  def item_details
+    {}
   end
 end

--- a/app/controllers/checkouts_controller.rb
+++ b/app/controllers/checkouts_controller.rb
@@ -7,4 +7,10 @@ class CheckoutsController < ApplicationController
   def index
     @checkouts = patron_or_group.checkouts.sort_by { |x| x.sort_key(:due_date) }
   end
+
+  private
+
+  def item_details
+    { circRecordList: true }
+  end
 end

--- a/app/controllers/fines_controller.rb
+++ b/app/controllers/fines_controller.rb
@@ -31,4 +31,8 @@ class FinesController < ApplicationController
   def payments
     (Hash.from_xml(Nokogiri::XML(payments_response).to_s) || {}).dig('LookupPatronInfoResponse', 'feeInfo')
   end
+
+  def item_details
+    { blockList: true }
+  end
 end

--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -74,4 +74,8 @@ class RequestsController < ApplicationController
   def not_needed_after_params
     params.require(%I[resource id not_needed_after])
   end
+
+  def item_details
+    { holdRecordList: true }
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -31,6 +31,8 @@ module ApplicationHelper
   # Wrap a link to the SearchWorks record for the given Catkey wrapped in the markup
   # necessary to be aligned with the content in the collapsible list sections
   def detail_link_to_searchworks(catkey)
+    return if catkey.blank?
+
     content_tag(:div, class: 'row') do
       content_tag(:div, class: 'col-11 offset-1 col-md-10 offset-md-2') do
         link_to Settings.sw.url + catkey, rel: 'noopener', target: '_blank' do

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -25,7 +25,7 @@ class Payment
   end
 
   def fee_pay_info
-    record['feePaymentInfo']
+    Array.wrap(record['feePaymentInfo']).first
   end
 
   def fee_item_info

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -24,14 +24,6 @@ class Payment
     Time.strptime(record['dateBilled'], '%Y-%m-%d')
   end
 
-  def fee_pay_info
-    Array.wrap(record['feePaymentInfo']).first
-  end
-
-  def fee_item_info
-    record['feeItemInfo']
-  end
-
   def item_title
     fee_item_info && fee_item_info['title'] || 'No item associated with this payment'
   end
@@ -61,5 +53,15 @@ class Payment
 
   def to_partial_path
     'fines/payment'
+  end
+
+  private
+
+  def fee_pay_info
+    Array.wrap(record['feePaymentInfo']).first
+  end
+
+  def fee_item_info
+    record['feeItemInfo']
   end
 end

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -37,23 +37,23 @@ class Request
   end
 
   def catkey
-    fields['bib']['key']
+    fields.dig('bib', 'key')
   end
 
   def title
-    bib['title']
+    bib && bib['title']
   end
 
   def author
-    bib['author']
+    bib && bib['author']
   end
 
   def call_number
-    call['dispCallNumber']
+    call && call['dispCallNumber']
   end
 
   def shelf_key
-    call['sortCallNumber']
+    call && call['sortCallNumber']
   end
 
   def queue_position
@@ -129,6 +129,6 @@ class Request
   end
 
   def call
-    fields['item']['fields']['call']['fields']
+    fields.dig('item', 'fields', 'call', 'fields')
   end
 end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -46,12 +46,26 @@ RSpec.describe ApplicationController do
       let(:patron) { Patron.new('fields' => { 'address1' => [], 'standing' => { 'key' => '' } }) }
 
       before do
-        allow(mock_client).to receive(:patron_info).with('123').and_return(patron)
+        allow(mock_client).to receive(:patron_info).with('123', item_details: {}).and_return(patron)
         warden.set_user(user)
       end
 
       it 'is a new instance of the Patron class' do
         expect(controller.patron).to be_an_instance_of Patron
+      end
+    end
+
+    context 'with some needed item details' do
+      before do
+        allow(mock_client).to receive(:patron_info)
+        warden.set_user(user)
+      end
+
+      it 'passes through the details' do
+        allow(controller).to receive(:item_details).and_return(some: :value)
+
+        controller.patron
+        expect(mock_client).to have_received(:patron_info).with('123', item_details: { some: :value })
       end
     end
 
@@ -66,7 +80,7 @@ RSpec.describe ApplicationController do
     let(:patron) { Patron.new('fields' => { 'address1' => [], 'standing' => { 'key' => '' } }) }
 
     before do
-      allow(mock_client).to receive(:patron_info).with('123').and_return(patron)
+      allow(mock_client).to receive(:patron_info).with('123', item_details: {}).and_return(patron)
       warden.set_user(user)
     end
 

--- a/spec/controllers/summaries_controller_spec.rb
+++ b/spec/controllers/summaries_controller_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe SummariesController do
     end
 
     before do
-      allow(mock_client).to receive(:patron_info).with('123').and_return(mock_response)
+      allow(mock_client).to receive(:patron_info).with('123', item_details: {}).and_return(mock_response)
       warden.set_user(user)
     end
 

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -64,6 +64,12 @@ RSpec.describe ApplicationHelper do
     it 'has a link to SerachWorks' do
       expect(content).to have_link(text: /View in SearchWorks/, href: %r{/view/12345$})
     end
+
+    context 'without a catkey' do
+      it 'returns nothing' do
+        expect(helper.detail_link_to_searchworks(nil)).to eq nil
+      end
+    end
   end
 
   describe '#sul_icon' do

--- a/spec/models/payment_spec.rb
+++ b/spec/models/payment_spec.rb
@@ -3,12 +3,9 @@
 require 'rails_helper'
 
 RSpec.describe Payment do
-  context 'with ana item associated with payment record' do
-    subject do
-      described_class.new(record.with_indifferent_access)
-    end
+  subject(:payment) { described_class.new(record.with_indifferent_access) }
 
-    let(:payment) { subject }
+  context 'with an item associated with payment record' do
     let(:record) do
       {
         'billNumber' => '5',
@@ -105,7 +102,7 @@ RSpec.describe Payment do
     end
   end
 
-    let(:payment) { subject }
+  context 'without item associated with payment' do
     let(:record) do
       {
         'billNumber' => '6',
@@ -163,11 +160,6 @@ RSpec.describe Payment do
   end
 
   context 'when there is no payment description but there is a payment amount' do
-    subject do
-      described_class.new(record.with_indifferent_access)
-    end
-
-    let(:payment) { subject }
     let(:record) do
       {
         'feePaymentInfo' => {
@@ -183,11 +175,6 @@ RSpec.describe Payment do
   end
 
   context 'when there is no payment description and no payment amount' do
-    subject do
-      described_class.new(record.with_indifferent_access)
-    end
-
-    let(:payment) { subject }
     let(:record) do
       {
         'feePaymentInfo' => {

--- a/spec/models/payment_spec.rb
+++ b/spec/models/payment_spec.rb
@@ -70,10 +70,40 @@ RSpec.describe Payment do
     end
   end
 
-  context 'without item associated with payment' do
-    subject do
-      described_class.new(record.with_indifferent_access)
+  context 'with multiple payments' do
+    let(:record) do
+      {
+        'billNumber' => '5',
+        'billReasonDescription' => 'Overdue recall',
+        'amount' => '21.00',
+        'dateBilled' => '2013-11-25',
+        'feePaymentInfo' => [
+          {
+            'paymentDate' => '2013-12-23',
+            'paymentAmount' => '21.00',
+            'paymentTypeID' => 'CREDITCARD',
+            'paymentTypeDescription' =>
+              'Payment using credit or debit card via MyAccount'
+          },
+          {
+            'paymentDate' => '2018-11-03',
+            'paymentAmount' => '1.00',
+            'paymentTypeID' => 'CREDITCARD',
+            'paymentTypeDescription' =>
+              'Payment using credit or debit card via MyAccount'
+          }
+        ],
+        'feeItemInfo' => {
+          'itemLibraryID' => 'GREEN',
+          'title' => 'California : a history'
+        }
+      }
     end
+
+    it 'picks the first one' do
+      expect(payment.payment_amount).to eq '21.00'
+    end
+  end
 
     let(:payment) { subject }
     let(:record) do

--- a/spec/models/request_spec.rb
+++ b/spec/models/request_spec.rb
@@ -71,4 +71,31 @@ RSpec.describe Request do
   it 'has the queue position' do
     expect(request.queue_position).to eq '3'
   end
+
+  context 'without an associated item or bib' do
+    before do
+      fields[:item] = nil
+      fields[:bib] = nil
+    end
+
+    it 'has no title' do
+      expect(request.title).to eq nil
+    end
+
+    it 'has no author' do
+      expect(request.author).to eq nil
+    end
+
+    it 'has no catkey' do
+      expect(request.catkey).to eq nil
+    end
+
+    it 'has no call number' do
+      expect(request.call_number).to eq nil
+    end
+
+    it 'has no shelf key' do
+      expect(request.shelf_key).to eq nil
+    end
+  end
 end

--- a/spec/services/symphony_client_spec.rb
+++ b/spec/services/symphony_client_spec.rb
@@ -66,6 +66,29 @@ RSpec.describe SymphonyClient do
     it 'authenticates the user against symphony' do
       expect(client.patron_info('somepatronkey')).to include 'key' => 'somepatronkey'
     end
+
+    context 'when requesting item details' do
+      it 'requests the item details for checkouts' do
+        client.patron_info('somepatronkey', item_details: { circRecordList: true })
+
+        expect(WebMock).to have_requested(:get, 'https://example.com/symws/user/patron/key/somepatronkey')
+          .with(query: hash_including(includeFields: match(/circRecordList{.*,item{.*}}/)))
+      end
+
+      it 'requests the item details for requests' do
+        client.patron_info('somepatronkey', item_details: { holdRecordList: true })
+
+        expect(WebMock).to have_requested(:get, 'https://example.com/symws/user/patron/key/somepatronkey')
+          .with(query: hash_including(includeFields: match(/holdRecordList{.*,item{.*}}/)))
+      end
+
+      it 'requests the item details for fines' do
+        client.patron_info('somepatronkey', item_details: { blockList: true })
+
+        expect(WebMock).to have_requested(:get, 'https://example.com/symws/user/patron/key/somepatronkey')
+          .with(query: hash_including(includeFields: match(/blockList{.*,item{.*}}/)))
+      end
+    end
   end
 
   describe '#renew_item' do


### PR DESCRIPTION
There's also some fixes for some real-world power-user problems in this branch so at least the app doesn't break on it. More analysis might be needed for these.

- fee payments can be multivalued (=> #317)
- sometimes requests don't have items associated (=> #313)

This improves the summary page load from 17s => 1s, although the checkouts page itself is still very slow.