### PR TITLE
Adds reCAPTCHA challenge to feedback form for non-logged in users

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -42,6 +42,10 @@ Metrics/MethodLength:
     - 'app/controllers/feedback_forms_controller.rb'
     - 'app/mailers/feedback_mailer.rb'
 
+Metrics/PerceivedComplexity:
+  Exclude:
+    - 'app/controllers/feedback_forms_controller.rb'
+
 RSpec/ExampleLength:
   Exclude:
     - 'spec/features/**/*'

--- a/Gemfile
+++ b/Gemfile
@@ -48,6 +48,8 @@ gem 'nokogiri'
 
 gem 'borrow_direct'
 
+gem 'recaptcha'
+
 group :production do
   gem 'mysql2', '~> 0.5'
   gem 'newrelic_rpm'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -239,6 +239,8 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)
       ffi (~> 1.0)
+    recaptcha (4.14.0)
+      json
     regexp_parser (1.6.0)
     rspec-core (3.8.2)
       rspec-support (~> 3.8.0)
@@ -388,6 +390,7 @@ DEPENDENCIES
   puma (~> 3.11)
   rails (~> 5.2.3)
   rails-controller-testing
+  recaptcha
   rspec-rails
   rubocop
   rubocop-performance

--- a/app/controllers/feedback_forms_controller.rb
+++ b/app/controllers/feedback_forms_controller.rb
@@ -29,6 +29,7 @@ class FeedbackFormsController < ApplicationController
 
   def validate
     errors = []
+    errors << 'You must pass the reCAPTCHA challenge' if !current_user? && !verify_recaptcha
     errors << 'A message is required' if params[:message].blank?
     if params[:email_address].present?
       errors << 'You have filled in a field that makes you appear as a spammer.  Please follow the directions for the individual form fields.'

--- a/app/views/shared/feedback_forms/_form.html.erb
+++ b/app/views/shared/feedback_forms/_form.html.erb
@@ -33,6 +33,17 @@
             <%= email_field_tag :to, "", class:"form-control" %>
           </div>
         </div>
+
+        <% unless current_user? %>
+          <div class="form-group row mylibrary-captcha">
+            <div class="col-sm-9 offset-sm-3">
+              <%= recaptcha_tags %>
+
+              <p>(Stanford users can avoid this Captcha by logging in.)</p>
+            </div>
+          </div>
+        <% end %>
+
         <div class="form-group row">
           <div class="col-sm-9 offset-sm-3">
             <button type="submit" class="btn btn-primary">Send</button>

--- a/config/initializers/recaptcha.rb
+++ b/config/initializers/recaptcha.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+Recaptcha.configure do |config|
+  config.site_key = Settings.RECAPTCHA.SITE_KEY
+  config.secret_key = Settings.RECAPTCHA.SECRET_KEY
+end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -10,3 +10,7 @@ sw:
 EMAIL_TO: yolo@example.com
 HOSTNAME: foo.example.com
 ACCESS_SERVICES_EMAIL: greencirc@stanford.edu
+RECAPTCHA:
+  SITE_KEY: 6Lc6BAAAAAAAAChqRbQZcn_yyyyyyyyyyyyyyyyy
+  SECRET_KEY: 6Lc6BAAAAAAAAKN3DRm6VA_xxxxxxxxxxxxxxxxx
+  

--- a/spec/controllers/feedback_forms_controller_spec.rb
+++ b/spec/controllers/feedback_forms_controller_spec.rb
@@ -3,6 +3,30 @@
 require 'rails_helper'
 
 RSpec.describe FeedbackFormsController do
+  context 'when the current user is anonymous' do
+    context 'when they fill in the reCAPTCHA' do
+      it 'sends an email (default scenario)' do
+        expect do
+          post :create, params: { url: 'http://test.host/', message: 'Howdy' }
+        end.to change(ActionMailer::Base.deliveries, :count).by(1)
+      end
+    end
+
+    context 'when they do not fill in the reCAPTCHA' do
+      # rubocop:disable RSpec/AnyInstance, RSpec/ExpectInHook
+      before do
+        expect_any_instance_of(described_class).to receive(:verify_recaptcha).and_return(false)
+      end
+      # rubocop:enable RSpec/AnyInstance, RSpec/ExpectInHook
+
+      it 'does not send an email' do
+        expect do
+          post :create, params: { url: 'http://test.host/', message: 'Howdy' }
+        end.not_to change(ActionMailer::Base.deliveries, :count)
+      end
+    end
+  end
+
   describe 'format json' do
     it 'return json success' do
       post :create, params: {

--- a/spec/features/feedback_form_spec.rb
+++ b/spec/features/feedback_form_spec.rb
@@ -3,6 +3,13 @@
 require 'rails_helper'
 
 RSpec.describe 'Feedback form', type: :feature do
+  context 'when not logged in' do
+    it 'reCAPTCHA challenge is present' do
+      visit feedback_path
+      expect(page).to have_css '.mylibrary-captcha'
+    end
+  end
+
   context 'with js', js: true do
     before do
       login_as(username: 'SUPER1', patron_key: '521181')
@@ -31,6 +38,11 @@ RSpec.describe 'Feedback form', type: :feature do
     before do
       login_as(username: 'SUPER1', patron_key: '521181')
       visit root_path
+    end
+
+    it 'reCAPTCHA challenge is present' do
+      visit feedback_path
+      expect(page).not_to have_css '.mylibrary-captcha'
     end
 
     it 'feedback form should be shown filled out and submitted' do


### PR DESCRIPTION
Fixes #42 

![Screen Shot 2019-07-29 at 5 04 55 PM](https://user-images.githubusercontent.com/1656824/62088580-03de2380-b223-11e9-969d-88a88156f84d.png)

To test locally, make sure to add the keys to your local settings.

Adapted from: https://github.com/sul-dlss/SearchWorks/pull/2009

In conjunction with:
https://github.com/sul-dlss/shared_configs/pull/991
https://github.com/sul-dlss/shared_configs/pull/992
https://github.com/sul-dlss/shared_configs/pull/993