### PR TITLE
Remove borrow limit from generic patron

### DIFF
--- a/app/views/patron/_patron.html.erb
+++ b/app/views/patron/_patron.html.erb
@@ -14,11 +14,6 @@
     <dd class="col-8 col-md-10 expired-date"><%= l(patron.expired_date, format: :short) %></dd>
   <% end %>
 
-  <% if patron.borrow_limit %>
-    <dt class="col-4 col-md-2 font-weight-normal">Borrower limit:</dt>
-    <dd class="col-8 col-md-10 patron-status"><%= pluralize(patron.borrow_limit, 'checkout') %></dd>
-  <% end %>
-
   <% if patron.email %>
     <dt class="col-4 col-md-2 font-weight-normal">Email:</dt>
     <dd class="col-8 col-md-10 email"><%= patron.email %></dd>


### PR DESCRIPTION
`Borrow limit` only applies to fee borrowers. Now that we fee borrowers have their own patron info partial (#318), we should be able to remove this from generic patron logic. See ["Patron info" in the content and labels doc.](https://docs.google.com/document/d/103F_NJJsBx-Bb7Op6nHGmwqylVcl5EvI7V67-PLa4Ho/edit#heading=h.v49m8d1k6ytw)