### PR TITLE
Implement breakpoint truncation changes fixes #330

### DIFF
--- a/app/assets/stylesheets/modules/checkouts.scss
+++ b/app/assets/stylesheets/modules/checkouts.scss
@@ -1,3 +1,5 @@
-.renewable-indicator {
-  margin-left: -20px;
+@include media-breakpoint-up(lg) {
+  .renewable-indicator {
+    margin-left: -20px;
+  }
 }

--- a/app/assets/stylesheets/modules/clamp.scss
+++ b/app/assets/stylesheets/modules/clamp.scss
@@ -5,3 +5,7 @@
 .clamp-2 {
   @include truncate-by-lines(2);
 }
+
+.clamp-3 {
+  @include truncate-by-lines(3);
+}

--- a/app/views/checkouts/_checkout.html.erb
+++ b/app/views/checkouts/_checkout.html.erb
@@ -1,10 +1,10 @@
 <li class="list-group-item <%= list_group_item_status_for_checkout(checkout)%>">
   <div class="row d-flex flex-wrap position-relative">
-    <div class="d-flex flex-row flex-grow-1 justify-content-between w-100 row col-md-4">
-      <div class="w-50 col-md-6 status" data-sort-status="<%= h checkout.sort_key(:status) %>">
+    <div class="d-flex flex-row flex-grow-1 justify-content-between align-items-baseline w-100 row col-md-4">
+      <div class="w-50 col-md-12 col-lg-6 status" data-sort-status="<%= h checkout.sort_key(:status) %>">
         <%= render_checkout_status(checkout) %>
       </div>
-      <div class="w-50 col-md-6 text-right text-md-left due_date" data-sort-date="<%= h checkout.sort_key(:due_date) %>">
+      <div class="w-50 col-md-12 col-lg-6 text-right align-items-baseline text-md-left due_date" data-sort-date="<%= h checkout.sort_key(:due_date) %>">
         <% if checkout.renewable? %>
           <span class="renewable-indicator">
             <%= sul_icon 'renew' %>
@@ -14,10 +14,10 @@
       </div>
     </div>
     <div class="d-flex flex-grow-1 flex-column flex-md-row w-75 row col-md-8">
-      <h3 class="col-md-7 clamp-2 record-title title text-reset" data-sort-title="<%= h checkout.sort_key(:title) %>"><%= checkout.title %></h3>
+      <h3 class="col-md-7 clamp-3 record-title title text-reset" data-sort-title="<%= h checkout.sort_key(:title) %>"><%= checkout.title %></h3>
       <div class="d-flex flex-row row col-md-5">
-        <div class="w-50 col-md-6 clamp-1 author" data-sort-author="<%= h checkout.sort_key(:author) %>"><%= checkout.author %></div>
-        <div class="w-50 col-md-6 call_number" data-sort-call_number="<%= h checkout.sort_key(:call_number) %>"><%= checkout.call_number %></div>
+        <div class="w-50 col-md-12 col-lg-6 clamp-1 author" data-sort-author="<%= h checkout.sort_key(:author) %>"><%= checkout.author %></div>
+        <div class="w-50 col-md-12 col-lg-6 call_number" data-sort-call_number="<%= h checkout.sort_key(:call_number) %>"><%= checkout.call_number %></div>
       </div>
     </div>
     <div>

--- a/app/views/checkouts/_recalled.html.erb
+++ b/app/views/checkouts/_recalled.html.erb
@@ -3,14 +3,14 @@
     <% if recalled.any? %>
       <div class="d-none d-md-flex row font-weight-bold list-header">
         <div class="row col-md-4">
-          <div class="col-md-6">Status</div>
-          <div class="col-md-6">Due date</div>
+          <div class="col-md-12 col-lg-6">Status</div>
+          <div class="col-md-12 col-lg-6">Due date</div>
         </div>
         <div class="row col-md-8">
           <div class="col-md-7">Title</div>
           <div class="row col-md-5">
-            <div class="col-md-6">Author</div>
-            <div class="col-md-6 call_number">Call number</div>
+            <div class="col-md-12 col-lg-6">Author</div>
+            <div class="col-md-12 col-lg-6 call_number">Call number</div>
           </div>
         </div>
       </div>

--- a/app/views/checkouts/index.html.erb
+++ b/app/views/checkouts/index.html.erb
@@ -34,14 +34,14 @@
 
     <div class="d-none d-md-flex row font-weight-bold list-header">
       <div class="row col-md-4">
-        <div class="col-md-6" data-sort="status">Status</div>
-        <div class="col-md-6 active" data-sort="due_date">Due date</div>
+        <div class="col-md-12 col-lg-6" data-sort="status">Status</div>
+        <div class="col-md-12 col-lg-6 active" data-sort="due_date">Due date</div>
       </div>
       <div class="row col-md-8">
         <div class="col-md-7" data-sort="title">Title</div>
         <div class="row col-md-5">
-          <div class="col-md-6" data-sort="author">Author</div>
-          <div class="col-md-6 call_number" data-sort="call_number">Call number</div>
+          <div class="col-md-12 col-lg-6" data-sort="author">Author</div>
+          <div class="col-md-12 col-lg-6 call_number" data-sort="call_number">Call number</div>
         </div>
       </div>
     </div>

--- a/app/views/fines/_fine.html.erb
+++ b/app/views/fines/_fine.html.erb
@@ -1,10 +1,10 @@
 <li class="list-group-item">
   <div class="row d-flex flex-wrap position-relative">
     <div class="d-flex flex-row flex-grow-1 justify-content-between w-100 row col-md-4">
-      <div class="w-50 col-md-6 status">
+      <div class="w-50 col-md-12 col-lg-6 status">
         <%= fine.nice_status %>
       </div>
-      <div class="w-50 col-md-6 text-right text-md-left owed">
+      <div class="w-50 col-md-12 col-lg-6 text-right text-md-left owed">
         <%= number_to_currency(fine.owed) %>
       </div>
     </div>
@@ -12,8 +12,8 @@
       <% if fine.bib? %>
         <h3 class="col-md-7 clamp-3 record-title title text-reset"><%= fine.title %></h3>
         <div class="d-flex flex-row row col-md-5">
-          <div class="w-50 col-md-6 clamp-1 author"><%= fine.author %></div>
-          <div class="w-50 col-md-6 call_number" data-shelfkey="<%= fine.shelf_key %>"><%= fine.call_number %></div>
+          <div class="w-50 col-md-12 col-lg-6 clamp-1 author"><%= fine.author %></div>
+          <div class="w-50 col-md-12 col-lg-6 call_number" data-shelfkey="<%= fine.shelf_key %>"><%= fine.call_number %></div>
         </div>
       <% end %>
     </div>

--- a/app/views/fines/_fine.html.erb
+++ b/app/views/fines/_fine.html.erb
@@ -10,7 +10,7 @@
     </div>
     <div class="d-flex flex-grow-1 flex-column flex-md-row w-75 row col-md-8">
       <% if fine.bib? %>
-        <h3 class="col-md-7 clamp-2 record-title title text-reset"><%= fine.title %></h3>
+        <h3 class="col-md-7 clamp-3 record-title title text-reset"><%= fine.title %></h3>
         <div class="d-flex flex-row row col-md-5">
           <div class="w-50 col-md-6 clamp-1 author"><%= fine.author %></div>
           <div class="w-50 col-md-6 call_number" data-shelfkey="<%= fine.shelf_key %>"><%= fine.call_number %></div>

--- a/app/views/fines/_payment.html.erb
+++ b/app/views/fines/_payment.html.erb
@@ -14,7 +14,7 @@
       </div>
     </div>
     <div class="d-flex flex-grow-1 flex-column flex-md-row w-75 row col-md-6">
-      <h3 class="col-md-10 clamp-2 record-title list-item-title"><%= payment.item_title %></h3>
+      <h3 class="col-md-10 clamp-3 record-title list-item-title"><%= payment.item_title %></h3>
     </div>
     <div>
       <button class="btn collapsed stretched-link" type="button" data-toggle="collapse" data-target="#collapseDetails-<%= payment.key.parameterize %>" aria-expanded="false" aria-controls="collapseDetails-<%= payment.key.parameterize %>">

--- a/app/views/fines/_payment.html.erb
+++ b/app/views/fines/_payment.html.erb
@@ -1,6 +1,6 @@
 <li class="list-group-item">
   <div class="row d-flex flex-wrap position-relative">
-    <div class="d-flex flex-row flex-grow-1 justify-content-start w-100 row col-md-6">
+    <div class="d-flex flex-row flex-grow-1 justify-content-start w-100 row col-md-12 col-lg-6">
       <div class="col-4 col-md-4 order-md-first description">
         <%= payment.bill_description %>
       </div>
@@ -13,7 +13,7 @@
         <%= l(payment.payment_date, format: :short) %>
       </div>
     </div>
-    <div class="d-flex flex-grow-1 flex-column flex-md-row w-75 row col-md-6">
+    <div class="d-flex flex-grow-1 flex-column flex-md-row w-75 row col-md-12 col-lg-6">
       <h3 class="col-md-10 clamp-3 record-title list-item-title"><%= payment.item_title %></h3>
     </div>
     <div>

--- a/app/views/fines/index.html.erb
+++ b/app/views/fines/index.html.erb
@@ -16,14 +16,14 @@
     </div>
     <div class="d-none d-md-flex row font-weight-bold list-header">
       <div class="row col-md-4">
-        <div class="col-md-6">Reason</div>
-        <div class="col-md-6">Amount</div>
+        <div class="col-md-12 col-lg-6">Reason</div>
+        <div class="col-md-12 col-lg-6">Amount</div>
       </div>
       <div class="row col-md-8">
         <div class="col-md-7">Title</div>
         <div class="row col-md-5">
-          <div class="col-md-6">Author</div>
-          <div class="col-md-6 call_number">Call number</div>
+          <div class="col-md-12 col-lg-6">Author</div>
+          <div class="col-md-12 col-lg-6 call_number">Call number</div>
         </div>
       </div>
     </div>
@@ -65,12 +65,12 @@
     </div>
 
     <div class="d-none d-md-flex row font-weight-bold list-header">
-      <div class="row col-md-6">
+      <div class="row col-md-12 col-lg-6">
         <div class="col-md-4" data-sort="reason">Reason</div>
         <div class="col-md-4" data-sort="amount">Amount</div>
         <div class="col-md-4 active" data-sort="due_date">Paid on</div>
       </div>
-      <div class="row col-md-6">
+      <div class="row col-md-12 col-lg-6">
         <div class="col-md-7" data-sort="title">Title</div>
       </div>
     </div>

--- a/app/views/requests/_borrow_direct_request.html.erb
+++ b/app/views/requests/_borrow_direct_request.html.erb
@@ -8,7 +8,7 @@
     </div>
   </div>
   <div class="d-flex flex-grow-1 flex-column flex-md-row w-75 row col-md-8">
-    <h3 class="col-md-7 clamp-2 record-title title text-reset"><%= borrow_direct_request.title %></h3>
+    <h3 class="col-md-7 clamp-3 record-title title text-reset"><%= borrow_direct_request.title %></h3>
     <div class="d-flex flex-row row col-md-5">
       <div class="w-50 col-md-6"></div>
       <div class="w-50 col-md-6"></div>

--- a/app/views/requests/_borrow_direct_request.html.erb
+++ b/app/views/requests/_borrow_direct_request.html.erb
@@ -1,17 +1,17 @@
 <li class="row d-flex flex-wrap list-group-item">
   <div class="d-flex flex-row flex-grow-1 justify-content-between w-100 row col-md-4">
-    <div class="w-50 col-md-6 library">
+    <div class="w-50 col-md-12 col-lg-6 library">
       <span class="d-md-none">Deliver to </span> Stanford
     </div>
-    <div class="w-50 col-md-6 text-right text-md-left date">
+    <div class="w-50 col-md-12 col-lg-6 text-right text-md-left date">
       In transit
     </div>
   </div>
   <div class="d-flex flex-grow-1 flex-column flex-md-row w-75 row col-md-8">
     <h3 class="col-md-7 clamp-3 record-title title text-reset"><%= borrow_direct_request.title %></h3>
     <div class="d-flex flex-row row col-md-5">
-      <div class="w-50 col-md-6"></div>
-      <div class="w-50 col-md-6"></div>
+      <div class="w-50 col-md-12 col-lg-6"></div>
+      <div class="w-50 col-md-12 col-lg-6"></div>
     </div>
   </div>
   <div>

--- a/app/views/requests/_request.html.erb
+++ b/app/views/requests/_request.html.erb
@@ -1,7 +1,7 @@
 <li class="list-group-item">
   <div class="row d-flex flex-wrap position-relative">
     <div class="d-flex flex-row flex-grow-1 justify-content-between w-100 row col-md-4">
-      <div class="w-50 col-md-6 library" data-sort-library="<%= h request.sort_key(:library) %>">
+      <div class="w-50 col-md-12 col-lg-6 library" data-sort-library="<%= h request.sort_key(:library) %>">
         <% if request.ready_for_pickup? %>
           <span class="text-ready">
             <%= sul_icon 'sharp-check_circle-24px' %>
@@ -13,11 +13,11 @@
 
       </div>
       <% if request.expiration_date %>
-        <div class="w-50 col-md-6 text-right text-md-left date" data-sort-date="<%= h request.sort_key(:date) %>">
+        <div class="w-50 col-md-12 col-lg-6 text-right text-md-left date" data-sort-date="<%= h request.sort_key(:date) %>">
           <%= l(request.expiration_date, format: :short) %>
         </div>
       <% elsif request.fill_by_date %>
-        <div class="w-50 col-md-6 text-right text-md-left date" data-sort-date="<%= h request.sort_key(:date) %>">
+        <div class="w-50 col-md-12 col-lg-6 text-right text-md-left date" data-sort-date="<%= h request.sort_key(:date) %>">
           <%= l(request.fill_by_date, format: :short) %>
         </div>
       <% end %>
@@ -25,8 +25,8 @@
     <div class="d-flex flex-grow-1 flex-column flex-md-row w-75 row col-md-8">
       <h3 class="col-md-7 clamp-3 record-title title text-reset" data-sort-title="<%= h request.sort_key(:title) %>"><%= request.title %></h3>
       <div class="d-flex flex-row row col-md-5">
-        <div class="w-50 col-md-6 clamp-1 author" data-sort-author="<%= h request.sort_key(:author) %>"><%= request.author %></div>
-        <div class="w-50 col-md-6 call_number" data-sort-call_number="<%= h request.sort_key(:call_number) %>"><%= request.call_number %></div>
+        <div class="w-50 col-md-12 col-lg-6 clamp-1 author" data-sort-author="<%= h request.sort_key(:author) %>"><%= request.author %></div>
+        <div class="w-50 col-md-12 col-lg-6 call_number" data-sort-call_number="<%= h request.sort_key(:call_number) %>"><%= request.call_number %></div>
       </div>
     </div>
     <div>

--- a/app/views/requests/_request.html.erb
+++ b/app/views/requests/_request.html.erb
@@ -23,7 +23,7 @@
       <% end %>
     </div>
     <div class="d-flex flex-grow-1 flex-column flex-md-row w-75 row col-md-8">
-      <h3 class="col-md-7 clamp-2 record-title title text-reset" data-sort-title="<%= h request.sort_key(:title) %>"><%= request.title %></h3>
+      <h3 class="col-md-7 clamp-3 record-title title text-reset" data-sort-title="<%= h request.sort_key(:title) %>"><%= request.title %></h3>
       <div class="d-flex flex-row row col-md-5">
         <div class="w-50 col-md-6 clamp-1 author" data-sort-author="<%= h request.sort_key(:author) %>"><%= request.author %></div>
         <div class="w-50 col-md-6 call_number" data-sort-call_number="<%= h request.sort_key(:call_number) %>"><%= request.call_number %></div>

--- a/app/views/requests/index.html.erb
+++ b/app/views/requests/index.html.erb
@@ -14,14 +14,14 @@
 
     <div class="d-none d-md-flex row font-weight-bold list-header">
       <div class="row col-md-4">
-        <div class="col-md-6">Pickup library</div>
-        <div class="col-md-6 active">Pickup by</div>
+        <div class="col-md-12 col-lg-6">Pickup library</div>
+        <div class="col-md-12 col-lg-6 active">Pickup by</div>
       </div>
       <div class="row col-md-8">
         <div class="col-md-7">Title</div>
         <div class="row col-md-5">
-          <div class="col-md-6">Author</div>
-          <div class="col-md-6 call_number">Call number</div>
+          <div class="col-md-12 col-lg-6">Author</div>
+          <div class="col-md-12 col-lg-6 call_number">Call number</div>
         </div>
       </div>
     </div>
@@ -53,14 +53,14 @@
   <% if @requests.any? %>
     <div class="d-none d-md-flex row font-weight-bold list-header">
       <div class="row col-md-4">
-        <div class="col-md-6" data-sort="library">Deliver to</div>
-        <div class="col-md-6 active" data-sort="date">Not needed after</div>
+        <div class="col-md-12 col-lg-6" data-sort="library">Deliver to</div>
+        <div class="col-md-12 col-lg-6 active" data-sort="date">Not needed after</div>
       </div>
       <div class="row col-md-8">
         <div class="col-md-7" data-sort="title">Title</div>
         <div class="row col-md-5">
-          <div class="col-md-6" data-sort="author">Author</div>
-          <div class="col-md-6 call_number" data-sort="call_number">Call number</div>
+          <div class="col-md-12 col-lg-6" data-sort="author">Author</div>
+          <div class="col-md-12 col-lg-6 call_number" data-sort="call_number">Call number</div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Fixes #330
The main changes here:
 - Only do the renewable-indicator negative margin when on lg and above screens
 - Move everything from 2 -> 3 line truncation
 - Modify how checkouts stack in md and below sizes

I paired with @jvine on the final details.

![Screen Shot 2019-07-30 at 10 52 01 AM](https://user-images.githubusercontent.com/1656824/62149041-1b1b2080-b2b8-11e9-9794-917eef3a9488.png)
![Screen Shot 2019-07-30 at 10 51 47 AM](https://user-images.githubusercontent.com/1656824/62149042-1b1b2080-b2b8-11e9-858a-a2de6a314785.png)
