### PR TITLE
Update the payment cancel flash message to use sentence case in the …

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -66,4 +66,4 @@ en:
       success: Thank you! Your feedback has been sent.
     fine_payment:
       accept_html: <span class="font-weight-bold">Success!</span> $%{amount} paid. A receipt has been sent to the email address associated with your account. Payment may take up to 5 minutes to appear in your payment history.
-      cancel_html: <span class="font-weight-bold">Payment Canceled.</span> No payment was made -- your payable balance remains unchanged.
+      cancel_html: <span class="font-weight-bold">Payment canceled.</span> No payment was made &mdash; your payable balance remains unchanged.

--- a/spec/controllers/payments_controller_spec.rb
+++ b/spec/controllers/payments_controller_spec.rb
@@ -29,8 +29,8 @@ RSpec.describe PaymentsController do
     end
 
     it 'flashes an error message' do
-      expect(flash[:error]).to eq '<span class="font-weight-bold">Payment Canceled.</span> No payment was made '\
-                                          '-- your payable balance remains unchanged.'
+      expect(flash[:error]).to eq '<span class="font-weight-bold">Payment canceled.</span> No payment was made '\
+                                          '&mdash; your payable balance remains unchanged.'
     end
   end
 end


### PR DESCRIPTION
…bolded text and an `mdash` instead of a double hyphen.

Closes #353

<img width="725" alt="Screen Shot 2019-07-30 at 9 18 49 PM" src="https://user-images.githubusercontent.com/96776/62183648-d327e800-b30f-11e9-9e85-df5f28266c65.png">

