### PR TITLE
Add btn btn-link classes so that cancel button gets spaced consistently

### DIFF
--- a/app/views/shared/contact_forms/_form.html.erb
+++ b/app/views/shared/contact_forms/_form.html.erb
@@ -20,7 +20,7 @@
       </div>
       <div class="col-12">
         <button type="submit" class="btn btn-primary">Send</button>
-        <%= link_to 'Cancel', :back, class: 'cancel-link', data: { dismiss: 'modal' } %>
+        <%= link_to 'Cancel', :back, class: 'btn btn-link cancel-link', data: { dismiss: 'modal' } %>
       </div>
     </div>
   <% end %>


### PR DESCRIPTION
Fixes #355 

![Screen Shot 2019-07-31 at 7 49 58 AM](https://user-images.githubusercontent.com/1656824/62217433-d77fef80-b367-11e9-90ab-b6c71de0dc3c.png)
