### PR TITLE
Consider SUL sourced checkouts to be from BorrowDirect…

### DIFF
--- a/app/models/checkout.rb
+++ b/app/models/checkout.rb
@@ -4,6 +4,7 @@
 class Checkout
   attr_reader :record
 
+  BORROW_DIRECT_CODE = 'BORROW_DIRECT'
   SHORT_TERM_LOAN_PERIODS = %w[HOURLY].freeze
 
   def initialize(record)
@@ -101,7 +102,10 @@ class Checkout
   end
 
   def library
-    fields['library']['key']
+    code = fields['library']['key']
+    return BORROW_DIRECT_CODE if code == 'SUL'
+
+    code
   end
 
   def catkey

--- a/app/views/checkouts/_checkout.html.erb
+++ b/app/views/checkouts/_checkout.html.erb
@@ -76,6 +76,6 @@
       <dd class="col-8"><%= library_name checkout.library %></dd>
     </dl>
 
-    <%= detail_link_to_searchworks(checkout.catkey) %>
+    <%= detail_link_to_searchworks(checkout.catkey) unless checkout.library == Checkout::BORROW_DIRECT_CODE %>
   </div>
 </li>

--- a/config/application.rb
+++ b/config/application.rb
@@ -72,6 +72,7 @@ module Mylibrary
       'ARS' => 'Archive of Recorded Sound',
       'ART' => 'Art & Architecture Library (Bowes)',
       'BIOLOGY' => 'Biology Library (Falconer)',
+      'BORROW_DIRECT' => 'BorrowDirect',
       'BUSINESS' => 'Business Library',
       'CHEMCHMENG' => 'Chemistry & ChemEng Library (Swain)',
       'CLASSICS' => 'Classics Library',

--- a/spec/models/checkout_spec.rb
+++ b/spec/models/checkout_spec.rb
@@ -268,4 +268,12 @@ RSpec.describe Checkout do
   it 'does not have a claimed returned date' do
     expect(checkout.claims_returned_date).to be_nil
   end
+
+  context 'when the library is SUL' do
+    before { fields[:library] = { key: 'SUL' } }
+
+    it 'represents itself as coming from BorrowDirect' do
+      expect(checkout.library).to eq 'BORROW_DIRECT'
+    end
+  end
 end

--- a/spec/views/checkouts/_checkout.html.erb_spec.rb
+++ b/spec/views/checkouts/_checkout.html.erb_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'checkouts/_checkout.html.erb' do
+  let(:checkout_attributes) { {} }
+  let(:checkout) do
+    instance_double(
+      Checkout,
+      accrued: nil,
+      author: '',
+      call_number: '',
+      catkey: '12345',
+      checkout_date: Time.zone.now - 120.days,
+      claimed_returned?: false,
+      days_overdue: nil,
+      days_remaining: 120,
+      due_date: Time.zone.now + 120.days,
+      item_key: nil,
+      key: 'abc123',
+      library: 'GREEN',
+      lost?: false,
+      overdue?: false,
+      patron_key: 'xyz321',
+      recalled?: false,
+      recalled_date: nil,
+      renewable?: false,
+      renewal_date: nil,
+      resource: nil,
+      short_term_loan?: false,
+      sort_key: nil,
+      title: 'Checkout Title',
+      **checkout_attributes
+    )
+  end
+
+  let(:patron) { instance_double(Patron, can_renew?: false) }
+
+  before do
+    controller.singleton_class.class_eval do
+      protected
+
+      def checkout; end
+
+      def patron; end
+      helper_method :checkout, :patron
+    end
+
+    allow(view).to receive(:checkout).and_return(checkout)
+    allow(view).to receive(:patron).and_return(patron)
+
+    render
+  end
+
+  it 'links to the item in SearchWorks' do
+    expect(rendered).to have_link(
+      'View in SearchWorks',
+      href: 'https://searchworks.stanford.edu/view/12345'
+    )
+  end
+
+  context 'when the library is BORROW_DIRECT' do
+    let(:checkout_attributes) { { library: Checkout::BORROW_DIRECT_CODE } }
+
+    it 'does not include a link to the item in SearchWorks' do
+      expect(rendered).not_to have_link('View in SearchWorks')
+    end
+  end
+end


### PR DESCRIPTION
…(and do not attempt to link to the SearchWorks record)

Closes #389

<img width="1138" alt="Screen Shot 2019-08-01 at 9 37 11 AM" src="https://user-images.githubusercontent.com/96776/62311423-a45d5f00-b440-11e9-9307-66dab07f526f.png">
