### PR TITLE
Add empty placeholders for fines with no bib record

### DIFF
--- a/app/views/fines/_fine.html.erb
+++ b/app/views/fines/_fine.html.erb
@@ -8,15 +8,13 @@
         <%= number_to_currency(fine.owed) %>
       </div>
     </div>
-    <% if fine.bib? %>
-      <div class="order-1 order-md-1 d-flex col-10 col-md-5 align-items-baseline">
-        <h3 class="clamp-3 record-title title text-reset"><%= fine.title %></h3>
-      </div>
-      <div class="order-3 order-md-2 d-flex flex-row flex-grow-1 row col-md-3">
-        <div class="w-50 col-md-12 col-lg-6 clamp-1 author"><%= fine.author %></div>
-        <div class="w-50 col-md-12 col-lg-6 call_number" data-shelfkey="<%= fine.shelf_key %>"><%= fine.call_number %></div>
-      </div>
-    <% end %>
+    <div class="order-1 order-md-1 d-flex col-10 col-md-5 align-items-baseline">
+      <h3 class="clamp-3 record-title title text-reset"><%= fine.title if fine.bib? %></h3>
+    </div>
+    <div class="order-3 order-md-2 d-flex flex-row flex-grow-1 row col-md-3">
+      <div class="w-50 col-md-12 col-lg-6 clamp-1 author"><%= fine.author if fine.bib? %></div>
+      <div class="w-50 col-md-12 col-lg-6 call_number" data-shelfkey="<%= fine.shelf_key if fine.bib? %>"><%= fine.call_number if fine.bib? %></div>
+    </div>
     <button class="col-2 col-md order-2 order-md-3 btn collapsed stretched-link" type="button" data-toggle="collapse" data-target="#collapseDetails-<%= fine.key.parameterize %>" aria-expanded="false" aria-controls="collapseDetails-<%= fine.key.parameterize %>">
       <span class="expand-icon"><%= sul_icon :'sharp-add-24px' %><span class="sr-only">Expand</span></span>
       <span class="collapse-icon"><%= sul_icon :'sharp-remove-24px' %><span class="sr-only">Collapse</span></span>


### PR DESCRIPTION
Fixes #404 

## Before
<img width="1168" alt="weird indents for fines with no associated book" src="https://user-images.githubusercontent.com/5402927/62335255-fffb0d00-b47f-11e9-97d5-fbcef375863d.png">

## After
<img width="1176" alt="fixed indents for fines with no associated book" src="https://user-images.githubusercontent.com/5402927/62335238-ec4fa680-b47f-11e9-92e0-99e857cf9878.png">