### PR TITLE
Does not render the fines table when viewing other proxies fines

### DIFF
--- a/app/views/fines/index.html.erb
+++ b/app/views/fines/index.html.erb
@@ -9,11 +9,7 @@
   <h2>Payable: <%= number_to_currency(@fines.sum(&:owed)) %></h2>
 
   <% if @fines.any? && !params[:payment_pending] %>
-      <% unless params[:group] && patron.sponsor? %>
-        <div class="mb-3">
-          <%= render 'fines/pay_all_button' %>
-        </div>
-      <% else %>
+      <% if params[:group] && patron.sponsor? # temporary fix until Symphony CGI scripts are updated %>
         <div class="pb-3">
           Fines can be paid in My Library Account only by the borrower who accrued them. <br />
           To pay group fines using iJournal,
@@ -21,21 +17,32 @@
               contact Circulation & Privileges.
           <% end %>
         </div>
+      <% elsif params[:group] %>
+        <div class="pb-3">
+          <%= sul_icon :'sharp-error-24px', classes: 'text-recalled' %> The research group has unpaid fines that may affect the status of all proxies.
+        </div>
+      <% else %>
+        <div class="mb-3">
+          <%= render 'fines/pay_all_button' %>
+        </div>
       <% end %>
-      <div class="d-none d-md-flex row font-weight-bold list-header">
-        <div class="row col-md-4">
-          <div class="col-md-12 col-lg-6">Reason</div>
-          <div class="col-md-12 col-lg-6">Amount</div>
+
+      <% unless params[:group] && !patron.sponsor? %>
+        <div class="d-none d-md-flex row font-weight-bold list-header">
+          <div class="row col-md-4">
+            <div class="col-md-12 col-lg-6">Reason</div>
+            <div class="col-md-12 col-lg-6">Amount</div>
+          </div>
+          <div class="col-md-5">Title</div>
+          <div class="row col-md-3">
+            <div class="col-md-12 col-lg-6">Author</div>
+            <div class="col-md-12 col-lg-6 call_number">Call number</div>
+          </div>
         </div>
-        <div class="col-md-5">Title</div>
-        <div class="row col-md-3">
-          <div class="col-md-12 col-lg-6">Author</div>
-          <div class="col-md-12 col-lg-6 call_number">Call number</div>
-        </div>
-      </div>
-      <ul class="fines list-group">
-        <%= render @fines %>
-      </ul>
+        <ul class="fines list-group">
+          <%= render @fines %>
+        </ul>
+      <% end %>
   <% end %>
 </div>
 

--- a/spec/features/proxy_user_spec.rb
+++ b/spec/features/proxy_user_spec.rb
@@ -55,6 +55,7 @@ RSpec.describe 'Proxy User', type: :feature do
     expect(page).not_to have_text('Borrower:')
 
     click_link 'Other proxies'
+    expect(page).not_to have_css('.fines')
     expect(page).not_to have_text('Aspects of grammatical architecture')
     expect(page).not_to have_text('SecondproxyLN')
   end


### PR DESCRIPTION
Closes #388

## Before
Proxy23 can see Proxy21's fines.
<img width="1155" alt="Screen Shot 2019-08-01 at 5 36 28 PM" src="https://user-images.githubusercontent.com/5402927/62335973-0b9c0300-b483-11e9-91f9-70705d1320dd.png">

## After
Proxy23 cannot see Proxy21's fines, does not have a pay button, and gets a notification.
<img width="1158" alt="Screen Shot 2019-08-01 at 5 36 12 PM" src="https://user-images.githubusercontent.com/5402927/62335974-0b9c0300-b483-11e9-9cb7-8d66b9238950.png">
