### PR TITLE
Override renewal errors for title-level holds

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -23,3 +23,4 @@ home_page_flash_message_html: |-
 
 symphony:
   host:
+  override: PASSWORD


### PR DESCRIPTION
Fixes #391 

This can be manually tested by putting in a request on searchworks-morison for a title. With the current app, the item will not be renewable. With this commit, the item will be renewed (after receiving the initial rejecting and following up with a prompt override) 