### PR TITLE
Add some labels to checkout and request dates for the mobile view only; fixes #418

### DIFF
--- a/app/views/checkouts/_checkout.html.erb
+++ b/app/views/checkouts/_checkout.html.erb
@@ -10,6 +10,7 @@
             <%= sul_icon 'renew' %>
           </span>
         <% end %>
+        <span class="d-inline d-md-none mr-2">Due</span>
         <%= today_with_time_or_date(checkout.due_date, short_term: checkout.short_term_loan?) %>
       </div>
     </div>

--- a/app/views/requests/_request.html.erb
+++ b/app/views/requests/_request.html.erb
@@ -14,10 +14,12 @@
       </div>
       <% if request.expiration_date %>
         <div class="w-50 col-md-12 col-lg-6 text-right text-md-left date" data-sort-date="<%= h request.sort_key(:date) %>">
+          <span class="d-inline d-md-none mr-2">by</span>
           <%= l(request.expiration_date, format: :short) %>
         </div>
       <% elsif request.fill_by_date %>
         <div class="w-50 col-md-12 col-lg-6 text-right text-md-left date" data-sort-date="<%= h request.sort_key(:date) %>">
+        <span class="d-inline d-md-none mr-2">Exp.</span>
           <%= l(request.fill_by_date, format: :short) %>
         </div>
       <% end %>


### PR DESCRIPTION
In mobile:
<img width="193" alt="Screen Shot 2019-08-02 at 13 42 21" src="https://user-images.githubusercontent.com/111218/62397687-69842580-b52b-11e9-8a0d-cc7428f3bb05.png">
<img width="169" alt="Screen Shot 2019-08-02 at 13 42 39" src="https://user-images.githubusercontent.com/111218/62397702-73a62400-b52b-11e9-83e9-6fbecf044522.png">
<img width="159" alt="Screen Shot 2019-08-02 at 13 42 41" src="https://user-images.githubusercontent.com/111218/62397705-756fe780-b52b-11e9-9e35-69e150a60a90.png">

And, expanded:
<img width="208" alt="Screen Shot 2019-08-02 at 13 42 51" src="https://user-images.githubusercontent.com/111218/62397711-7b65c880-b52b-11e9-9ce6-4c05c5bf23dc.png">
