### PR TITLE
Requests for on-order items do not have queue length or position.

### DIFF
--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -77,6 +77,8 @@ class Request
   end
 
   def waitlist_position
+    return 'Unknown' if queue_position.nil? && queue_length.nil?
+
     "#{queue_position} of #{queue_length}"
   end
 

--- a/spec/models/request_spec.rb
+++ b/spec/models/request_spec.rb
@@ -98,4 +98,16 @@ RSpec.describe Request do
       expect(request.shelf_key).to eq nil
     end
   end
+
+  context 'when a hold is for an on order item' do
+    before do
+      fields[:item] = nil
+      fields[:queuePosition] = nil
+      fields[:queueLength] = nil
+    end
+
+    it 'has an unknown waitlist position' do
+      expect(request.waitlist_position).to eq 'Unknown'
+    end
+  end
 end


### PR DESCRIPTION
Some holds, like title-level for things on-order return nil values for queueLength and queuePosition:
<img width="1135" alt="Screen Shot 2019-08-02 at 10 03 39 PM" src="https://user-images.githubusercontent.com/6343464/62407963-a37a1980-b575-11e9-92e2-4b8d4ae56d94.png">

This makes the waitlist position "Unknown" for these situations:
<img width="1124" alt="Screen Shot 2019-08-02 at 10 33 04 PM" src="https://user-images.githubusercontent.com/6343464/62407965-b55bbc80-b575-11e9-80bb-ef9afe4470e8.png">
