### PR TITLE
 Show 'Source: BorrowDirect' for requests (in addition to checkouts)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -28,6 +28,7 @@ Metrics/ClassLength:
     - 'app/models/checkout.rb'
     - 'app/models/patron.rb'
     - 'app/models/payment.rb'
+    - 'app/models/request.rb'
     - 'app/services/symphony_client.rb'
     - 'config/application.rb'
 

--- a/app/models/checkout.rb
+++ b/app/models/checkout.rb
@@ -4,7 +4,6 @@
 class Checkout
   attr_reader :record
 
-  BORROW_DIRECT_CODE = 'BORROW_DIRECT'
   SHORT_TERM_LOAN_PERIODS = %w[HOURLY].freeze
 
   def initialize(record)
@@ -116,9 +115,13 @@ class Checkout
 
   def library
     code = fields['library']['key']
-    return BORROW_DIRECT_CODE if code == 'SUL'
+    return Settings.BORROW_DIRECT_CODE if from_borrow_direct?
 
     code
+  end
+
+  def from_borrow_direct?
+    fields.dig('library', 'key') == 'SUL'
   end
 
   def catkey

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -87,7 +87,15 @@ class Request
   end
 
   def placed_library
-    fields['placedLibrary']['key']
+    code = fields['placedLibrary']['key']
+
+    return Settings.BORROW_DIRECT_CODE if from_borrow_direct?
+
+    code
+  end
+
+  def from_borrow_direct?
+    fields.dig('placedLibrary', 'key') == 'SUL'
   end
 
   # rubocop:disable Metrics/AbcSize,Metrics/MethodLength

--- a/app/views/checkouts/_checkout.html.erb
+++ b/app/views/checkouts/_checkout.html.erb
@@ -78,6 +78,6 @@
       <dd class="col-8"><%= library_name checkout.library %></dd>
     </dl>
 
-    <%= detail_link_to_searchworks(checkout.catkey) unless checkout.library == Checkout::BORROW_DIRECT_CODE %>
+    <%= detail_link_to_searchworks(checkout.catkey) unless checkout.from_borrow_direct? %>
   </div>
 </li>

--- a/app/views/requests/_request.html.erb
+++ b/app/views/requests/_request.html.erb
@@ -71,6 +71,6 @@
       <dd class="col-8"><%= library_name request.placed_library %></dd>
     </dl>
 
-    <%= detail_link_to_searchworks(request.catkey) %>
+    <%= detail_link_to_searchworks(request.catkey) unless request.from_borrow_direct? %>
   </div>
 </li>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -24,3 +24,5 @@ home_page_flash_message_html: |-
 symphony:
   host:
   override: PASSWORD
+
+BORROW_DIRECT_CODE: BORROW_DIRECT

--- a/spec/models/checkout_spec.rb
+++ b/spec/models/checkout_spec.rb
@@ -276,6 +276,10 @@ RSpec.describe Checkout do
     expect(checkout.library).to eq 'LAW'
   end
 
+  it 'is not from borrow direct' do
+    expect(checkout).not_to be_from_borrow_direct
+  end
+
   it 'has a title' do
     expect(checkout.title).to eq 'The Lego movie videogame [electronic resource]'
   end
@@ -365,6 +369,10 @@ RSpec.describe Checkout do
 
     it 'represents itself as coming from BorrowDirect' do
       expect(checkout.library).to eq 'BORROW_DIRECT'
+    end
+
+    it 'is from borrow direct' do
+      expect(checkout).to be_from_borrow_direct
     end
   end
 end

--- a/spec/models/request_spec.rb
+++ b/spec/models/request_spec.rb
@@ -72,6 +72,10 @@ RSpec.describe Request do
     expect(request.queue_position).to eq '3'
   end
 
+  it 'is not from borrow direct' do
+    expect(request).not_to be_from_borrow_direct
+  end
+
   context 'without an associated item or bib' do
     before do
       fields[:item] = nil
@@ -108,6 +112,18 @@ RSpec.describe Request do
 
     it 'has an unknown waitlist position' do
       expect(request.waitlist_position).to eq 'Unknown'
+    end
+  end
+
+  context 'when the placed_library is SUL' do
+    before { fields[:placedLibrary] = { key: 'SUL' } }
+
+    it 'represents itself as coming from BorrowDirect' do
+      expect(request.placed_library).to eq 'BORROW_DIRECT'
+    end
+
+    it 'is from borrow direct' do
+      expect(request).to be_from_borrow_direct
     end
   end
 end

--- a/spec/views/checkouts/_checkout.html.erb_spec.rb
+++ b/spec/views/checkouts/_checkout.html.erb_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe 'checkouts/_checkout.html.erb' do
       days_overdue: nil,
       days_remaining: 120,
       due_date: Time.zone.now + 120.days,
+      from_borrow_direct?: false,
       item_key: nil,
       key: 'abc123',
       library: 'GREEN',
@@ -46,10 +47,9 @@ RSpec.describe 'checkouts/_checkout.html.erb' do
       helper_method :checkout, :patron
     end
 
-    allow(view).to receive(:checkout).and_return(checkout)
     allow(view).to receive(:patron).and_return(patron)
 
-    render
+    render 'checkouts/checkout', checkout: checkout
   end
 
   it 'links to the item in SearchWorks' do
@@ -60,7 +60,7 @@ RSpec.describe 'checkouts/_checkout.html.erb' do
   end
 
   context 'when the library is BORROW_DIRECT' do
-    let(:checkout_attributes) { { library: Checkout::BORROW_DIRECT_CODE } }
+    let(:checkout_attributes) { { from_borrow_direct?: true } }
 
     it 'does not include a link to the item in SearchWorks' do
       expect(rendered).not_to have_link('View in SearchWorks')

--- a/spec/views/requests/_request.html.erb_spec.rb
+++ b/spec/views/requests/_request.html.erb_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'requests/_request.html.erb' do
+  let(:request_attributes) { {} }
+  let(:mock_request) do
+    instance_double(
+      Request,
+      author: 'Some Author',
+      call_number: '',
+      catkey: '12345',
+      expiration_date: Time.zone.now + 1.day,
+      from_borrow_direct?: false,
+      key: 'abc123',
+      pickup_library: 'XYZ',
+      placed_date: Time.zone.now,
+      placed_library: 'SAL3',
+      ready_for_pickup?: false,
+      sort_key: '1',
+      title: 'A Book',
+      waitlist_position: nil,
+      **request_attributes
+    )
+  end
+
+  let(:patron) { instance_double(Patron, can_modify_requests?: false) }
+
+  before do
+    controller.singleton_class.class_eval do
+      protected
+
+      def patron; end
+      helper_method :request, :patron
+    end
+
+    allow(view).to receive(:patron).and_return(patron)
+
+    render partial: 'requests/request', locals: { request: mock_request }
+  end
+
+  it 'links to the item in SearchWorks' do
+    expect(rendered).to have_link(
+      'View in SearchWorks',
+      href: 'https://searchworks.stanford.edu/view/12345'
+    )
+  end
+
+  context 'when the library is BORROW_DIRECT' do
+    let(:request_attributes) { { from_borrow_direct?: true } }
+
+    it 'does not include a link to the item in SearchWorks' do
+      expect(rendered).not_to have_link('View in SearchWorks')
+    end
+  end
+end


### PR DESCRIPTION
Fixes #434 