### PR TITLE
Extract a BibRecord mixin

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -29,7 +29,6 @@ Metrics/ClassLength:
     - 'app/models/checkout.rb'
     - 'app/models/patron.rb'
     - 'app/models/payment.rb'
-    - 'app/models/request.rb'
     - 'app/services/symphony_client.rb'
     - 'config/application.rb'
 

--- a/app/models/checkout.rb
+++ b/app/models/checkout.rb
@@ -2,6 +2,8 @@
 
 # Model for the Checkouts page
 class Checkout
+  include BibRecord
+
   attr_reader :record
 
   SHORT_TERM_LOAN_PERIODS = %w[HOURLY].freeze
@@ -91,14 +93,6 @@ class Checkout
     fields['patron']['key']
   end
 
-  def resource
-    fields['item']['resource']
-  end
-
-  def item_key
-    fields['item']['key']
-  end
-
   def overdue?
     fields['overdue']
   end
@@ -124,40 +118,12 @@ class Checkout
     fields.dig('library', 'key') == 'SUL'
   end
 
-  def catkey
-    fields['item']['fields']['bib']['key']
-  end
-
-  def title
-    bib['title']
-  end
-
-  def author
-    bib['author']
-  end
-
-  def call_number
-    call['dispCallNumber']
-  end
-
-  def shelf_key
-    call['sortCallNumber']
-  end
-
   def short_term_loan?
     SHORT_TERM_LOAN_PERIODS.include?(loan_period_type)
   end
 
   def to_partial_path
     'checkouts/checkout'
-  end
-
-  def current_location
-    fields.dig('item', 'fields', 'currentLocation', 'key')
-  end
-
-  def lost?
-    current_location == 'LOST-ASSUM'
   end
 
   # rubocop:disable Metrics/AbcSize,Metrics/MethodLength
@@ -203,14 +169,6 @@ class Checkout
 
   def loan_period_type
     fields.dig('circulationRule', 'fields', 'loanPeriod', 'fields', 'periodType', 'key')
-  end
-
-  def bib
-    fields['item']['fields']['bib']['fields']
-  end
-
-  def call
-    fields['item']['fields']['call']['fields']
   end
 
   def circulation_rule

--- a/app/models/concerns/bib_record.rb
+++ b/app/models/concerns/bib_record.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+# Common accessors into bib item data
+module BibRecord
+  def catkey
+    fields.dig('bib', 'key') || item.dig('bib', 'key')
+  end
+
+  def title
+    bib['title']
+  end
+
+  def author
+    bib['author']
+  end
+
+  def call_number
+    call['dispCallNumber']
+  end
+
+  def shelf_key
+    call['sortCallNumber']
+  end
+
+  def resource
+    fields.dig('item', 'resource')
+  end
+
+  def item_key
+    fields.dig('item', 'key')
+  end
+
+  def home_location
+    item.dig('homeLocation', 'key')
+  end
+
+  def current_location
+    item.dig('currentLocation', 'key')
+  end
+
+  def lost?
+    current_location == 'LOST-ASSUM'
+  end
+
+  private
+
+  def item
+    fields.dig('item', 'fields') || {}
+  end
+
+  def bib
+    fields.dig('bib', 'fields') || fields.dig('item', 'fields', 'bib', 'fields') || {}
+  end
+
+  def call
+    item.dig('call', 'fields') || {}
+  end
+end

--- a/app/models/fine.rb
+++ b/app/models/fine.rb
@@ -2,6 +2,8 @@
 
 # Model for the Fine page
 class Fine
+  include BibRecord
+
   attr_reader :record
 
   FINE_STATUS = {
@@ -57,26 +59,6 @@ class Fine
     FINE_STATUS[status] || status
   end
 
-  def catkey
-    bib && fields['item']['fields']['bib']['key']
-  end
-
-  def title
-    bib && bib['title']
-  end
-
-  def author
-    bib && bib['author']
-  end
-
-  def call_number
-    call && call['dispCallNumber']
-  end
-
-  def shelf_key
-    call && call['sortCallNumber']
-  end
-
   def library
     fields['library']['key']
   end
@@ -105,13 +87,5 @@ class Fine
 
   def fields
     record['fields']
-  end
-
-  def bib
-    fields['item'] && fields['item']['fields']['bib'] && fields['item']['fields']['bib']['fields']
-  end
-
-  def call
-    fields['item'] && fields['item']['fields']['call'] && fields['item']['fields']['call']['fields']
   end
 end

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -2,6 +2,8 @@
 
 # Model for requests in Symphony
 class Request
+  include BibRecord
+
   # A sufficiently large time used to sort nil values last
   # TODO: Update before 2099
   END_OF_DAYS = Time.zone.parse('2099-01-01')
@@ -34,26 +36,6 @@ class Request
 
   def ready_for_pickup?
     status == 'BEING_HELD'
-  end
-
-  def catkey
-    fields.dig('bib', 'key')
-  end
-
-  def title
-    bib && bib['title']
-  end
-
-  def author
-    bib && bib['author']
-  end
-
-  def call_number
-    call && call['dispCallNumber']
-  end
-
-  def shelf_key
-    call && call['sortCallNumber']
   end
 
   def queue_position
@@ -124,21 +106,9 @@ class Request
   end
   # rubocop:enable Metrics/AbcSize,Metrics/MethodLength
 
-  def home_location
-    fields['item']['fields']['homeLocation']['key']
-  end
-
   private
 
   def fields
     record['fields']
-  end
-
-  def bib
-    fields.dig('bib', 'fields')
-  end
-
-  def call
-    fields.dig('item', 'fields', 'call', 'fields')
   end
 end


### PR DESCRIPTION
This pulls over all the accessors we made for `bib`/`item`/`call` data into a common mixin that is nice and defensive about missing data (in a consistent way across checkouts, requests, and fines).