### PR TITLE
Stop loading spinner if no payment history is available

### DIFF
--- a/app/views/payments/index.html.erb
+++ b/app/views/payments/index.html.erb
@@ -1,8 +1,7 @@
-<% if @payments.any? %>
-  <div id="payments" class="page-section">
-    <div class="d-flex justify-content-between">
-      <h2>History</h2>
-
+<div id="payments" class="page-section">
+  <% if @payments.any? %>
+  <div class="d-flex justify-content-between">
+    <h2>History</h2>
       <div class="dropdown">
         <a class="btn btn-secondary dropdown-toggle" href="#" role="button" id="dropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
           Sort (<span data-sort-label>Date paid</span>)
@@ -15,8 +14,13 @@
           <li class="dropdown-item" data-sort="bill_amount">Amount</li>
         </ul>
       </div>
-    </div>
+  </div>
+  <% else %>
+    <h2>History</h2>
+    <span>There is no history on this account.</span>
+  <% end %>
 
+  <% if @payments.any? %>
     <div class="d-none d-md-flex row font-weight-bold list-header">
       <div class="row col-md-12 col-lg-6">
         <div class="col-md-4" data-sort="bill_description">Reason</div>
@@ -31,5 +35,5 @@
     <ul class="payments list list-group">
       <%= render @payments %>
     </ul>
-  </div>
-<% end %>
+  <% end %>
+</div>

--- a/spec/features/fines_spec.rb
+++ b/spec/features/fines_spec.rb
@@ -4,8 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'Fines Page', type: :feature do
   let(:user_with_payments) { '521181' }
-  let(:user_witout_fines) { '521206' }
-  let(:user_with_single_payment) { '521182' }
+  let(:user_without_fines) { '521206' }
 
   before do
     login_as(username: 'SUPER1', patron_key: user_with_payments)
@@ -49,92 +48,9 @@ RSpec.describe 'Fines Page', type: :feature do
     end
   end
 
-  context 'with multiple payments' do
-    it 'has a header for payment history' do
-      visit fines_path
-
-      expect(page).to have_css('h2', text: 'History')
-    end
-
-    it 'renders a list item for every payment', js: true do
-      visit fines_path
-      click_on 'Show history'
-
-      within('ul.payments') do
-        expect(page).to have_css('li', count: 2)
-        expect(page).to have_css('li h3', text: 'California : a history')
-        expect(page).to have_css('li .bill_description', text: 'Overdue item')
-      end
-    end
-
-    it 'has content behind a payments toggle', js: true do
-      visit fines_path
-      click_on 'Show history'
-
-      within('ul.payments') do
-        within(first('li')) do
-          expect(page).not_to have_css('dl', visible: true)
-          expect(page).not_to have_css('dt', text: 'Resolution', visible: true)
-          click_button 'Expand'
-          expect(page).to have_css('dl', visible: true)
-          expect(page).to have_css('dt', text: 'Resolution', visible: true)
-        end
-      end
-    end
-
-    it 'is sortable', js: true do
-      visit fines_path
-      click_on 'Show history'
-
-      within '#payments' do
-        expect(page).to have_css('.dropdown-toggle', text: 'Sort (Date paid)')
-        find('[data-sort="bill_description"]').click
-
-        expect(page).to have_css('.dropdown-toggle', text: 'Sort (Reason)')
-        expect(page).to have_css('.active[data-sort="bill_description"]', count: 2, visible: false)
-
-        within(first('ul.payments li')) do
-          expect(page).to have_css('.bill_description', text: /Overdue item/)
-        end
-      end
-    end
-  end
-
-  context 'when user has a single payment' do
-    before do
-      login_as(username: 'SUPER2', patron_key: user_with_single_payment)
-    end
-
-    it 'renders a list item for a single payment', js: true do
-      visit fines_path
-      click_on 'Show history'
-
-      within('ul.payments') do
-        expect(page).to have_css('li', count: 1)
-        expect(page).to have_css('li h3', text: 'No item associated with this payment')
-        expect(page).to have_css('li .bill_description', text: 'Privileges fee')
-      end
-    end
-
-    it 'has content behind a payments toggle', js: true do
-      visit fines_path
-      click_on 'Show history'
-
-      within('ul.payments') do
-        within(first('li')) do
-          expect(page).not_to have_css('dl', visible: true)
-          expect(page).not_to have_css('dt', text: 'Resolution', visible: true)
-          click_button 'Expand'
-          expect(page).to have_css('dl', visible: true)
-          expect(page).to have_css('dt', text: 'Resolution', visible: true)
-        end
-      end
-    end
-  end
-
   context 'with no fines' do
     before do
-      login_as(username: 'NOTHING', patron_key: user_witout_fines)
+      login_as(username: 'NOTHING', patron_key: user_without_fines)
     end
 
     it 'does not render table headers' do

--- a/spec/features/payments_spec.rb
+++ b/spec/features/payments_spec.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Payments History', type: :feature do
+  let(:user_with_payments) { '521181' }
+  let(:user_with_single_payment) { '521182' }
+
+  before do
+    login_as(username: 'SUPER1', patron_key: user_with_payments)
+  end
+
+  context 'when user has a single payment' do
+    before do
+      login_as(username: 'SUPER2', patron_key: user_with_single_payment)
+    end
+
+    it 'renders a list item for a single payment', js: true do
+      visit fines_path
+      click_on 'Show history'
+
+      within('ul.payments') do
+        expect(page).to have_css('li', count: 1)
+        expect(page).to have_css('li h3', text: 'No item associated with this payment')
+        expect(page).to have_css('li .bill_description', text: 'Privileges fee')
+      end
+    end
+
+    it 'has content behind a payments toggle', js: true do
+      visit fines_path
+      click_on 'Show history'
+
+      within('ul.payments') do
+        within(first('li')) do
+          expect(page).not_to have_css('dl', visible: true)
+          expect(page).not_to have_css('dt', text: 'Resolution', visible: true)
+          click_button 'Expand'
+          expect(page).to have_css('dl', visible: true)
+          expect(page).to have_css('dt', text: 'Resolution', visible: true)
+        end
+      end
+    end
+  end
+
+  context 'with multiple payments' do
+    it 'has a header for payment history' do
+      visit fines_path
+
+      expect(page).to have_css('h2', text: 'History')
+    end
+
+    it 'renders a list item for every payment', js: true do
+      visit fines_path
+      click_on 'Show history'
+
+      within('ul.payments') do
+        expect(page).to have_css('li', count: 2)
+        expect(page).to have_css('li h3', text: 'California : a history')
+        expect(page).to have_css('li .bill_description', text: 'Overdue item')
+      end
+    end
+
+    it 'has content behind a payments toggle', js: true do
+      visit fines_path
+      click_on 'Show history'
+
+      within('ul.payments') do
+        within(first('li')) do
+          expect(page).not_to have_css('dl', visible: true)
+          expect(page).not_to have_css('dt', text: 'Resolution', visible: true)
+          click_button 'Expand'
+          expect(page).to have_css('dl', visible: true)
+          expect(page).to have_css('dt', text: 'Resolution', visible: true)
+        end
+      end
+    end
+
+    it 'is sortable', js: true do
+      visit fines_path
+      click_on 'Show history'
+
+      within '#payments' do
+        expect(page).to have_css('.dropdown-toggle', text: 'Sort (Date paid)')
+        find('[data-sort="bill_description"]').click
+
+        expect(page).to have_css('.dropdown-toggle', text: 'Sort (Reason)')
+        expect(page).to have_css('.active[data-sort="bill_description"]', count: 2, visible: false)
+
+        within(first('ul.payments li')) do
+          expect(page).to have_css('.bill_description', text: /Overdue item/)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes #436 

If a user has no fines, stop the loading spinner and returns the message:

![Screen Shot 2019-08-05 at 9 59 25 AM](https://user-images.githubusercontent.com/5402927/62481619-bfdda800-b767-11e9-9d8a-4f9371a7eaa6.png)

