### PR TITLE
Update borrowdirect requests using the DOM structure for other requests

### DIFF
--- a/app/views/requests/_borrow_direct_request.html.erb
+++ b/app/views/requests/_borrow_direct_request.html.erb
@@ -1,24 +1,26 @@
-<li class="row d-flex flex-wrap list-group-item">
-  <div class="d-flex flex-row flex-grow-1 justify-content-between w-100 row col-md-4">
-    <div class="w-50 col-md-12 col-lg-6 library">
-      <span class="d-md-none">Deliver to </span> Stanford
+<li class="list-group-item">
+  <div class="row d-flex flex-wrap position-relative justify-content-between">
+    <div class="d-flex flex-row flex-grow-1 justify-content-between w-100 row col-md-4">
+      <div class="w-50 col-md-12 col-lg-6 library" data-sort-library="<%= h borrow_direct_request.sort_key(:library) %>">
+        <span class="d-md-none">Deliver to </span> Stanford
+      </div>
+      <div class="w-50 col-md-12 col-lg-6 text-right text-md-left date" data-sort-date="<%= h borrow_direct_request.sort_key(:date) %>">
+        In transit
+      </div>
     </div>
-    <div class="w-50 col-md-12 col-lg-6 text-right text-md-left date">
-      In transit
+    <div class="order-1 order-md-1 col-10 col-md-5 align-items-baseline">
+      <h3 class="clamp-3 record-title title text-reset" data-sort-title="<%= h borrow_direct_request.sort_key(:title) %>"><%= borrow_direct_request.title %></h3>
     </div>
+    <div class="order-3 order-md-2 d-flex flex-row flex-grow-1 row col-md-3">
+      <div class="w-50 col-md-12 col-lg-6 clamp-1 author" data-sort-author="<%= h borrow_direct_request.sort_key(:author) %>"></div>
+      <div class="w-50 col-md-12 col-lg-6 call_number" data-sort-call_number="<%= h borrow_direct_request.sort_key(:call_number) %>"></div>
+    </div>
+    <button class="col-2 col-md order-2 order-md-3 btn collapsed stretched-link position-static" type="button" data-toggle="collapse" data-target="#collapseDetails-<%= borrow_direct_request.key.parameterize %>" aria-expanded="false" aria-controls="collapseDetails-<%= borrow_direct_request.key.parameterize %>">
+      <span class="expand-icon"><%= sul_icon :'sharp-add-24px' %><span class="sr-only">Expand</span></span>
+      <span class="collapse-icon"><%= sul_icon :'sharp-remove-24px' %><span class="sr-only">Collapse</span></span>
+    </button>
   </div>
-  <div class="order-1 order-md-1 d-flex col-10 col-md-5 align-items-baseline">
-    <h3 class="clamp-3 record-title title text-reset"><%= borrow_direct_request.title %></h3>
-  </div>
-  <div class="order-3 order-md-2 d-flex flex-row flex-grow-1 row col-md-3">
-    <div class="w-50 col-md-12 col-lg-6"></div>
-    <div class="w-50 col-md-12 col-lg-6"></div>
-  </div>
-  <button class="col-2 col-md order-2 order-md-3 d-flex col-2 col-md btn collapsed" type="button" data-toggle="collapse" data-target="#collapseRequest-<%= borrow_direct_request.key %>" aria-expanded="false" aria-controls="collapseRequest-<%= borrow_direct_request.key %>">
-    <span class="expand-icon"><%= sul_icon :'sharp-add-24px' %><span class="sr-only">Expand</span></span>
-    <span class="collapse-icon"><%= sul_icon :'sharp-remove-24px' %><span class="sr-only">Collapse</span></span>
-  </button>
-  <div class="collapse w-100" id="collapseRequest-<%= borrow_direct_request.key %>">
+  <div class="collapse w-100" id="collapseDetails-<%= borrow_direct_request.key.parameterize %>">
     <dl class="row mb-0">
       <dt class="col-3 offset-1 col-md-2 offset-md-2">Requested:</dt>
       <dd class="col-8"><%= l(borrow_direct_request.date_submitted, format: :short) %></dd>


### PR DESCRIPTION

<img width="760" alt="Screen Shot 2019-08-07 at 07 57 01" src="https://user-images.githubusercontent.com/111218/62633469-0575ae80-b8e9-11e9-80d2-f981aee86de6.png">
Fixes #452

