### PR TITLE
Only render the not_needed_after date selector when the request has …

### DIFF
--- a/app/views/requests/edit.html.erb
+++ b/app/views/requests/edit.html.erb
@@ -8,15 +8,17 @@
     <%= hidden_field_tag :id, @request.key %>
     <%= hidden_field_tag :title, @request.title %>
     <%= hidden_field_tag :group, params[:group] if params[:group] %>
-    <%= hidden_field_tag :current_fill_by_date, @request.fill_by_date.strftime('%Y-%m-%d') %>
+    <%= hidden_field_tag :current_fill_by_date, @request&.fill_by_date&.strftime('%Y-%m-%d') %>
     <div class="form-group">
       <%= label_tag :pickup_library, 'Pickup library' %>
       <%= select_tag :pickup_library, request_location_options(@request), include_blank: library_name(@request.pickup_library), class: 'form-control' %>
     </div>
-    <div class="form-group">
-      <%= label_tag :not_needed_after, 'Not needed after', class: 'form-label' %>
-      <%= date_field_tag :not_needed_after, @request.fill_by_date.strftime('%Y-%m-%d'), class: 'form-control' %>
-    </div>
+    <% if @request.fill_by_date %>
+      <div class="form-group">
+        <%= label_tag :not_needed_after, 'Not needed after', class: 'form-label' %>
+        <%= date_field_tag :not_needed_after, @request.fill_by_date.strftime('%Y-%m-%d'), class: 'form-control' %>
+      </div>
+    <% end %>
     <div class="form-group pb-3">
       <div class="form-text">
         Cancel this request

--- a/spec/views/requests/edit.html.erb_spec.rb
+++ b/spec/views/requests/edit.html.erb_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'requests/edit.html.erb' do
+  let(:request_attributes) { {} }
+  let(:mock_request) do
+    instance_double(
+      Request,
+      title: 'Request Title',
+      key: 'abc123',
+      resource: nil,
+      fill_by_date: nil,
+      pickup_library: 'GREEN',
+      home_location: 'SAL3',
+      **request_attributes
+    )
+  end
+
+  before do
+    assign(:request, mock_request)
+    render
+  end
+
+  context 'when the request has a fill_by_date' do
+    let(:request_attributes) { { fill_by_date: Time.zone.parse('2019-01-01') } }
+
+    it 'has a date selector to update the fill_by_date' do
+      expect(rendered).to have_css('input[type="date"][name="not_needed_after"]')
+    end
+  end
+
+  context 'when the request has no fill_by_date' do
+    it 'does not have a date selector to update the fill_by_date' do
+      expect(rendered).not_to have_css('input[type="date"][name="not_needed_after"]')
+    end
+  end
+end


### PR DESCRIPTION
…a not_needed_after date.

The [default for requests](https://github.com/sul-dlss/sul-requests/blob/ce2713cbf02c8d953f68261343547c02cf8ccd36/app/models/concerns/default_request_options.rb#L18-L20) is to not have a needed after date.  [All Hold/Recalls](https://github.com/sul-dlss/sul-requests/blob/ce2713cbf02c8d953f68261343547c02cf8ccd36/app/models/requests/hold_recall.rb#L22-L24) will have a not_needed_after date as well as [some MediatedPages](https://github.com/sul-dlss/sul-requests/blob/ce2713cbf02c8d953f68261343547c02cf8ccd36/app/models/requests/mediated_page.rb#L45-L50).


Fixes #462 

## Before
<img width="556" alt="Screen Shot 2019-08-09 at 4 30 21 PM" src="https://user-images.githubusercontent.com/96776/62814277-b3898000-bac4-11e9-99f6-cac7d412db61.png">

## After
<img width="529" alt="Screen Shot 2019-08-09 at 4 30 01 PM" src="https://user-images.githubusercontent.com/96776/62814276-b3898000-bac4-11e9-8dc0-37be1b4778c2.png">
