### PR TITLE
Add a configurable flash message for internal pages

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,6 +3,7 @@
 # :nodoc:
 class ApplicationController < ActionController::Base
   helper_method :current_user, :current_user?, :patron, :patron_or_group, :symphony_client
+  before_action :set_internal_pages_flash_message
 
   def current_user
     session_data = request.env['warden'].user
@@ -56,5 +57,15 @@ class ApplicationController < ActionController::Base
 
   def item_details
     {}
+  end
+
+  def set_internal_pages_flash_message
+    return unless Settings.internal_pages_flash_message_html && action_name == 'index'
+
+    Settings.internal_pages_flash_message_config.each do |controller|
+      # rubocop:disable Rails/OutputSafety
+      controller == controller_name && flash.now[:alert] = Settings.internal_pages_flash_message_html.html_safe
+      # rubocop:enable Rails/OutputSafety
+    end
   end
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -21,6 +21,13 @@ home_page_flash_message_html: |-
 
   <p class="mb-0">Use the feedback link to let us know what you think!</p>
 
+internal_pages_flash_message_html: |-
+  <p>As of Monday, 9/9/19, we are having an issue with renewing materials due on 9/23/19.  Renewals will be available on Tuesday, 9/10/19.</p>
+
+internal_pages_flash_message_config:
+  - summaries
+  - checkouts
+
 symphony:
   host:
   override: PASSWORD

--- a/spec/features/internal_flash_message_spec.rb
+++ b/spec/features/internal_flash_message_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Internal flash messages', type: :feature do
+  let(:user) { '521181' }
+
+  before do
+    login_as(username: 'SUPER1', patron_key: user)
+  end
+
+  context 'when message is set' do
+    before do
+      Settings.internal_pages_flash_message_config = ['summaries']
+      Settings.internal_pages_flash_message_html = '<p>Test message</p>'
+    end
+
+    it 'renders flash for a configured controller' do
+      visit summaries_url
+      within('div.alert') do
+        expect(page).to have_css('p', text: 'Test message')
+      end
+    end
+
+    it 'does not render flash for a non-configured controller' do
+      visit requests_url
+      expect(page).not_to have_css('p', text: 'Test message')
+    end
+  end
+
+  context 'when message is not set' do
+    before do
+      Settings.internal_pages_flash_message_config = []
+      Settings.internal_pages_flash_message_html = nil
+    end
+
+    it 'does not render flash if set message is empty' do
+      visit summaries_url
+      expect(page).not_to have_css('p', text: 'Test message')
+    end
+  end
+end


### PR DESCRIPTION
```
internal_pages_flash_message_html: |-
  <p>As of Monday, 9/9/19, we are having an issue with renewing materials due on 9/23/19.  Renewals will be available on Tuesday, 9/10/19.</p>

internal_pages_flash_message_config:
  - summaries
  - checkouts
```

🎃 squash these please