### PR TITLE
Unset flash msg

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -60,7 +60,7 @@ class ApplicationController < ActionController::Base
   end
 
   def set_internal_pages_flash_message
-    return unless Settings.internal_pages_flash_message_html && action_name == 'index'
+    return unless Settings.internal_pages_flash_message_html.present? && action_name == 'index'
 
     Settings.internal_pages_flash_message_config.each do |controller|
       # rubocop:disable Rails/OutputSafety

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -21,12 +21,9 @@ home_page_flash_message_html: |-
 
   <p class="mb-0">Use the feedback link to let us know what you think!</p>
 
-internal_pages_flash_message_html: |-
-  <p>As of Monday, 9/9/19, we are having an issue with renewing materials due on 9/23/19.  Renewals will be available on Tuesday, 9/10/19.</p>
+internal_pages_flash_message_html: ''
 
-internal_pages_flash_message_config:
-  - summaries
-  - checkouts
+internal_pages_flash_message_config: []
 
 symphony:
   host:


### PR DESCRIPTION
Renewals issue has been resolved. I also added a lil' check for whether the string is `present?` to account for a lil' edge case.
<img width="674" alt="flash message with empty string" src="https://user-images.githubusercontent.com/5402927/64641186-7d3f6900-d3c0-11e9-8689-c5da57a93ccc.png">
