### PR TITLE
Add check for nil library so checkouts list can display

### DIFF
--- a/app/models/checkout.rb
+++ b/app/models/checkout.rb
@@ -108,6 +108,9 @@ class Checkout
   end
 
   def library
+    # In some edge cases Symws returns an empty block for fields['library']
+    return '' if fields['library'].nil?
+
     code = fields['library']['key']
     return Settings.BORROW_DIRECT_CODE if from_borrow_direct?
 

--- a/spec/models/checkout_spec.rb
+++ b/spec/models/checkout_spec.rb
@@ -380,4 +380,12 @@ RSpec.describe Checkout do
       expect(checkout).to be_from_borrow_direct
     end
   end
+
+  context 'when the library is null' do
+    before { fields[:library] = nil }
+
+    it 'returns an empty string' do
+      expect(checkout.library).to eq ''
+    end
+  end
 end


### PR DESCRIPTION
Fixes #481 

Checks if `fields['library']` is nil and returns empty string

```
ActionView::Template::Error: undefined method `[]' for nil:NilClass

    checkout.rb 111 library(...)
    [PROJECT_ROOT]/app/models/checkout.rb:111:in `library'

    109 
    110   def library
    111     code = fields['library']['key']
    112     return Settings.BORROW_DIRECT_CODE if from_borrow_direct?
```