### PR TITLE
Add a more descriptive error message for SUNet ID users...

### DIFF
--- a/app/assets/stylesheets/base.scss
+++ b/app/assets/stylesheets/base.scss
@@ -47,6 +47,7 @@ h1 {
   color: $sul-h1-font-color;
   font-weight: 300;
   line-height: 1.2em;
+  margin-bottom: 30px;
 }
 
 h2 {

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -40,7 +40,9 @@ class SessionsController < ApplicationController
     if request.env['warden'].authenticate(:shibboleth, :development_shibboleth_stub)
       redirect_to summaries_url
     else
-      redirect_to root_url, alert: 'Unable to authenticate.'
+      redirect_to root_url, flash: {
+        error: t('mylibrary.sessions.login_by_sunetid.error_html', mailto: Settings.ACCESS_SERVICES_EMAIL)
+      }
     end
   end
 

--- a/app/views/sessions/index.html.erb
+++ b/app/views/sessions/index.html.erb
@@ -1,5 +1,4 @@
-<h1>Log in to your library account</h1>
-<p>See your checkouts, requests made from SearchWorks, and any fines or fees you owe.</p>
+<h1>Log in to see your checkouts, requests, fines &amp; fees</h1>
 
 <% if @symphony_ok %>
   <div class="row">

--- a/app/views/sessions/index.html.erb
+++ b/app/views/sessions/index.html.erb
@@ -37,3 +37,15 @@
     </li>
   </ul>
 </div>
+
+<div class="page-section">
+  <h2>Looking for online resources?</h2>
+  <p>
+    A library account is not required to access Stanford's e-resources. <br />
+    Find e-resources in
+    <%= link_to 'https://searchworks.stanford.edu', target: '_blank' do %>
+      <%= sul_icon :'sharp-open_in_new-24px' %> SearchWorks
+    <% end %>
+    and log in there with your SUNet ID.
+  </p>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -67,3 +67,11 @@ en:
     fine_payment:
       accept_html: <span class="font-weight-bold">Success!</span> $%{amount} paid. A receipt has been sent to the email address associated with your account. Payment may take up to 5 minutes to appear in your payment history.
       cancel_html: <span class="font-weight-bold">Payment canceled.</span> No payment was made &mdash; your payable balance remains unchanged.
+    sessions:
+      login_by_sunetid:
+        error_html: <p class="h3">Unable to log in. Your SUNet ID is not linked to a library account.</p>
+                    <ul>
+                      <li>You do not need a library account to access Stanford's e-resources.</li>
+                      <li>A library account is created for patrons who are eligible to check out library materials.</li>
+                      <li>If you believe you should have an account, contact <a href="mailto:%{mailto}">Circulation &amp; Privileges</a> for assistance.</li>
+                    </ul>

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -135,6 +135,11 @@ RSpec.describe SessionsController do
       it 'redirects failed requests back to the login page' do
         expect(get(:login_by_sunetid)).to redirect_to root_url
       end
+
+      it 'sets a flash error' do
+        get(:login_by_sunetid)
+        expect(flash[:error]).to include('Your SUNet ID is not linked to a library account')
+      end
     end
   end
 end

--- a/spec/features/reset_pin_spec.rb
+++ b/spec/features/reset_pin_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'Reset Pin', type: :feature do
 
     it 'logs out user and redirects to root' do
       visit reset_pin_path
-      expect(page).to have_css 'h1', text: 'Log in to your library account'
+      expect(page).to have_css 'h1', text: 'Log in to see your checkouts, requests, fines & fees'
     end
   end
 


### PR DESCRIPTION
...who fail to authenticate in Symphony.

Plus bonus home page updates!

Closes #490 

<img width="1147" alt="Screen Shot 2019-10-25 at 12 08 51 PM" src="https://user-images.githubusercontent.com/96776/67597926-277d1100-f721-11e9-8652-517c9f436fcf.png">
