### PR TITLE
Add a configurable global alert for winter closure

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -7,6 +7,7 @@
 @import 'su-identity-overrides';
 @import 'modules/clamp';
 @import 'modules/header_navbar';
+@import 'modules/global-alert';
 @import 'modules/list-items';
 @import 'modules/page-section';
 @import 'modules/navigation';

--- a/app/assets/stylesheets/modules/global-alert.scss
+++ b/app/assets/stylesheets/modules/global-alert.scss
@@ -1,0 +1,7 @@
+ $global-alert-color: rgb(204, 0, 0);
+
+.global-alert {
+  border: 1px solid $global-alert-color;
+  margin: 10px auto;
+  padding: 10px;
+}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -28,6 +28,7 @@
         <%= render '/shared/header' %>
         <%= content_for(:navigation) %>
         <main id="main" role="main" class="container mt-3 mb-3">
+          <%= render '/shared/global_alert' %>
           <%= render partial: '/shared/flash_msg', layout: nil %>
           <%= yield %>
         </main>

--- a/app/views/shared/_global_alert.html.erb
+++ b/app/views/shared/_global_alert.html.erb
@@ -1,0 +1,5 @@
+<% if Settings.GLOBAL_ALERT %>
+  <div class="global-alert">
+    <%= Settings.global_alert_html.html_safe %>
+  </div>
+<% end %>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -20,6 +20,9 @@ internal_pages_flash_message_html: ''
 
 internal_pages_flash_message_config: []
 
+GLOBAL_ALERT: <%= false %>
+global_alert_html: The Stanford Libraries will be operating on a reduced schedule during the Stanford Winter Closure period (December 21, 2019 - January 5, 2020).<br /><a href="https://library.stanford.edu/winterclosure">More information about schedules and affected services</a>
+
 symphony:
   host:
   override: PASSWORD


### PR DESCRIPTION
Fixes #505
We'll want to flip the switch in shared configs on the Wednesday before break.
![Global message set](https://user-images.githubusercontent.com/5402927/71045474-e46c6800-20e9-11ea-8a52-2440d25f7b53.png)

❗️ Note that this global message is _separate_ from the existing `home_page_flash_message_html` and the `internal_pages_flash_message_html`. 

### global message + internal flash message for requests
![Screen Shot 2019-12-17 at 4 22 00 PM](https://user-images.githubusercontent.com/5402927/71045473-e46c6800-20e9-11ea-9747-1212e029a0b5.png)

```YAML
internal_pages_flash_message_html: a requests-specific message
internal_pages_flash_message_config:
  - requests
GLOBAL_ALERT: <%= true %>
global_flash_message_html: The Stanford Libraries will be operating on a reduced schedule during the Stanford Winter Closure period (December 21, 2019 - January 5, 2020).<br /><a href="https://library.stanford.edu/winterclosure">More information about schedules and affected services</a>
```

### global message + home page message
![Screen Shot 2019-12-17 at 4 22 41 PM](https://user-images.githubusercontent.com/5402927/71045472-e46c6800-20e9-11ea-97fd-ce94b76b2a9e.png)
```YAML
home_page_flash_message_html: a blizzard in California?!
GLOBAL_ALERT: <%= true %>
global_flash_message_html: The Stanford Libraries will be operating on a reduced schedule during the Stanford Winter Closure period (December 21, 2019 - January 5, 2020).<br /><a href="https://library.stanford.edu/winterclosure">More information about schedules and affected services</a>
```
