### PR TITLE
Add a bit  more granular feature flags for the various schedule once …

### DIFF
--- a/app/models/patron.rb
+++ b/app/models/patron.rb
@@ -219,6 +219,8 @@ class Patron
   end
 
   def can_schedule_green_access?
+    return unless Settings.schedule_once.green_visits.enabled
+
     faculty = %w[CNF MXF]
     grad_students_and_postdocs = %w[MXD RED REG REG-SUM]
     visiting_scholars = %w[MXAS]
@@ -228,6 +230,8 @@ class Patron
   end
 
   def can_schedule_green_pickup?
+    return unless Settings.schedule_once.green_pickup.enabled
+
     faculty = %w[CNF MXF]
     grad_students_and_postdocs = %w[MXD RED REG REG-SUM]
     undergrads = %w[REU REU-SUM]
@@ -239,6 +243,8 @@ class Patron
   end
 
   def can_schedule_special_collections_visit?
+    return unless Settings.schedule_once.spec_visits.enabled
+
     can_schedule_green_access? && requests.any? { |r| r.pickup_library == 'SPEC-DESK' && r.ready_for_pickup? }
   end
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -35,3 +35,9 @@ BORROW_DIRECT_CODE: BORROW_DIRECT
 
 schedule_once:
   enabled: false
+  green_pickup:
+    enabled: false
+  green_visits:
+    enabled: false
+  spec_visits:
+    enabled: false

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -10,3 +10,9 @@ symphony:
 
 schedule_once:
   enabled: true
+  green_pickup:
+    enabled: true
+  green_visits:
+    enabled: true
+  spec_visits:
+    enabled: true


### PR DESCRIPTION
…links.

The theory being that because we allow visits to Green doesn't necessarily mean we'll be ready for pickup (even if a valid user has material for pickup) because the library staff may not be ready.