### PR TITLE
Only show green schedule buttons when the pickup library is GREEN

### DIFF
--- a/app/models/patron.rb
+++ b/app/models/patron.rb
@@ -239,7 +239,7 @@ class Patron
     staff = %w[CNAC CNS MXAC MXS]
 
     [*faculty, *grad_students_and_postdocs, *undergrads, *visiting_scholars, *staff].include?(profile_key) &&
-      requests.any? { |r| %w[GREEN MEDIA-MTXT].include?(r.pickup_library) && r.ready_for_pickup? }
+      requests.any? { |r| r.pickup_library == 'GREEN' && r.ready_for_pickup? }
   end
 
   def can_schedule_special_collections_visit?

--- a/spec/features/requests_spec.rb
+++ b/spec/features/requests_spec.rb
@@ -137,26 +137,6 @@ RSpec.describe 'Request Page', type: :feature do
       end
     end
 
-    context 'with an eligible patron with a pickup at Media Microtext' do
-      before do
-        fields[:profile]['key'] = 'MXF'
-        fields[:firstName] = 'My'
-        fields[:lastName] = 'Name'
-        fields[:holdRecordList] = [
-          { fields: { status: 'BEING_HELD', pickupLibrary: { key: 'MEDIA-MTXT' } } }
-        ]
-      end
-
-      it 'renders a button to schedule access to Green' do
-        visit summaries_path
-        click_link 'Schedule pickup at Green Library'
-        expect(page).to have_css '.modal-body iframe'
-        src = find('iframe')[:src]
-        expect(src).to start_with 'https://go.oncehub.com/StanfordLibrariesPagingPickupGreenLibrary'
-        expect(src).to include 'name=My%20Name'
-      end
-    end
-
     context 'with an eligible patron without a pickup at Green' do
       before do
         fields[:profile]['key'] = 'MXF'

--- a/spec/features/summaries_spec.rb
+++ b/spec/features/summaries_spec.rb
@@ -218,26 +218,6 @@ RSpec.describe 'Summaries Page', type: :feature do
         end
       end
 
-      context 'with an eligible patron with a pickup at Media Microtext' do
-        before do
-          fields[:profile]['key'] = 'MXF'
-          fields[:firstName] = 'My'
-          fields[:lastName] = 'Name'
-          fields[:holdRecordList] = [
-            { fields: { status: 'BEING_HELD', pickupLibrary: { key: 'MEDIA-MTXT' } } }
-          ]
-        end
-
-        it 'renders a button to schedule access to Green' do
-          visit summaries_path
-          click_link 'Schedule pickup at Green Library'
-          expect(page).to have_css '.modal-body iframe'
-          src = find('iframe')[:src]
-          expect(src).to start_with 'https://go.oncehub.com/StanfordLibrariesPagingPickupGreenLibrary'
-          expect(src).to include 'name=My%20Name'
-        end
-      end
-
       context 'with an eligible patron without a pickup at Green' do
         before do
           fields[:profile]['key'] = 'MXF'


### PR DESCRIPTION
MEDIA-MTXT items will be paged, but their pickup library will be GREEN not MEDIA-MTXT