### PR TITLE
Add a pickup_library accessor to BorrowDirect requests so they mimic …

### DIFF
--- a/app/models/borrow_direct_requests.rb
+++ b/app/models/borrow_direct_requests.rb
@@ -50,6 +50,8 @@ class BorrowDirectRequests
       end
     end
 
+    def pickup_library; end
+
     def expiration_date; end
 
     def fill_by_date; end


### PR DESCRIPTION
…the API of other requests.

[HB Error](https://app.honeybadger.io/projects/62116/faults/64715113)