### PR TITLE
Add a drop down for scheduling visits when a user has...

### DIFF
--- a/app/assets/stylesheets/modules/scheduling.scss
+++ b/app/assets/stylesheets/modules/scheduling.scss
@@ -4,3 +4,10 @@
   margin: 0 auto;
   width: 100%;
 }
+
+// Clear the border styling on link hovers in the scheduling dropdown
+.schedule-once-dropdown {
+  .dropdown-menu a:hover {
+    border-bottom: 0;
+  }
+}

--- a/app/helpers/summaries_helper.rb
+++ b/app/helpers/summaries_helper.rb
@@ -18,12 +18,29 @@ module SummariesHelper
     )
   end
 
+  def schedule_once_link_or_dropdown
+    return 'Not eligible during current phase of Research Restart Plan' if library_schedule_path_map.blank?
+
+    schedulable_libraries = library_schedule_path_map.keys
+
+    if schedulable_libraries.one?
+      return link_to_schedule_once_visit(
+        library: schedulable_libraries.first,
+        text: "🗓 Schedule access to #{library_name(schedulable_libraries.first)}",
+        css_class: 'btn btn-primary'
+      )
+    end
+
+    render 'schedules/schedule_library_visit_dropdown', schedulable_libraries: schedulable_libraries
+  end
+
   private
 
   def library_schedule_path_map
-    {
-      'EAST-ASIA' => schedule_eal_path,
-      'GREEN' => schedule_green_path
-    }
+    map = {}
+    map['GREEN'] = schedule_green_path if patron_or_group.can_schedule_green_access?
+    map['EAST-ASIA'] = schedule_eal_path if patron_or_group.can_schedule_eal_access?
+
+    map
   end
 end

--- a/app/helpers/summaries_helper.rb
+++ b/app/helpers/summaries_helper.rb
@@ -7,4 +7,23 @@ module SummariesHelper
       a << [k, ERB::Util.url_encode(v)].join('=')
     end.join('&')
   end
+
+  def link_to_schedule_once_visit(library:, text:, css_class: nil)
+    link_to(
+      text,
+      library_schedule_path_map[library],
+      role: 'button',
+      class: css_class,
+      data: { 'mylibrary-modal': 'trigger' }
+    )
+  end
+
+  private
+
+  def library_schedule_path_map
+    {
+      'EAST-ASIA' => schedule_eal_path,
+      'GREEN' => schedule_green_path
+    }
+  end
 end

--- a/app/models/patron.rb
+++ b/app/models/patron.rb
@@ -229,6 +229,17 @@ class Patron
       (profile_key == 'CNAC' && affiliations.include?('affiliate:fellow'))
   end
 
+  def can_schedule_eal_access?
+    return unless Settings.schedule_once.eal_visits.enabled
+
+    faculty = %w[CNF MXF]
+    grad_students_and_postdocs = %w[MXD RED REG REG-SUM]
+    visiting_scholars = %w[MXAS]
+
+    [*faculty, *grad_students_and_postdocs, *visiting_scholars].include?(profile_key) ||
+      (profile_key == 'CNAC' && affiliations.include?('affiliate:fellow'))
+  end
+
   def can_schedule_green_pickup?
     return unless Settings.schedule_once.green_pickup.enabled
 

--- a/app/views/schedules/_schedule_library_visit_dropdown.html.erb
+++ b/app/views/schedules/_schedule_library_visit_dropdown.html.erb
@@ -1,0 +1,10 @@
+<div class="schedule-once-dropdown dropdown">
+  <button class="btn btn-primary dropdown-toggle" type="button" id="scheduleOnceDropdown" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+    🗓 Schedule access to ...
+  </button>
+  <div class="dropdown-menu" aria-labelledby="scheduleOnceDropdown">
+    <% schedulable_libraries.each do |library| %>
+      <%= link_to_schedule_once_visit(library: library, text: library_name(library), css_class: 'dropdown-item') %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/summaries/index.html.erb
+++ b/app/views/summaries/index.html.erb
@@ -12,13 +12,7 @@
     <dl class="row">
       <dt class="col-5 col-sm-4 col-md-3 col-lg-2 font-weight-normal">Library access:</dt>
       <dd class="col-7 col-sm-8 col-md-9 col-lg-10 library-access">
-        <% if patron_or_group.can_schedule_green_access? %>
-          <%= link_to schedule_green_path, role: 'button', class: 'btn btn-primary', data: { 'mylibrary-modal': 'trigger' } do %>
-            🗓 Schedule access to Green Library
-          <% end %>
-        <% else %>
-          Not eligible during current phase of Research Restart Plan
-        <% end %>
+        <%= schedule_once_link_or_dropdown %>
 
         <div class="mt-1">
           <%= link_to 'https://library.stanford.edu/returntoresearch', target: '_blank' do %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   root to: 'sessions#index'
+  get 'schedule/eal' => 'schedules#show', oncehub_id: 'StanfordLibrariesEastAsiaLibraryEntry'
   get 'schedule/green' => 'schedules#show', oncehub_id: 'StanfordLibrariesGreenEntry'
   get 'schedule/spec' => 'schedules#show', oncehub_id: 'StanfordLibrariesVisitSpecialCollections'
   get 'schedule/pickup' => 'schedules#show', oncehub_id: 'StanfordLibrariesPagingPickupGreenLibrary'

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -35,6 +35,8 @@ BORROW_DIRECT_CODE: BORROW_DIRECT
 
 schedule_once:
   enabled: false
+  eal_visits:
+    enabled: false
   green_pickup:
     enabled: false
   green_visits:

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -10,6 +10,8 @@ symphony:
 
 schedule_once:
   enabled: true
+  eal_visits:
+    enabled: true
   green_pickup:
     enabled: true
   green_visits:

--- a/spec/features/summaries_spec.rb
+++ b/spec/features/summaries_spec.rb
@@ -190,7 +190,10 @@ RSpec.describe 'Summaries Page', type: :feature do
         it 'renders a button to schedule access to Green' do
           visit summaries_path
 
-          click_link 'Schedule access to Green Library'
+          within '.schedule-once-dropdown' do
+            click_link 'Green Library'
+          end
+
           expect(page).to have_css '.modal-body iframe'
           src = find('iframe')[:src]
           expect(src).to start_with 'https://go.oncehub.com/StanfordLibrariesGreenEntry'

--- a/spec/helpers/summaries_helper_spec.rb
+++ b/spec/helpers/summaries_helper_spec.rb
@@ -12,19 +12,72 @@ RSpec.describe SummariesHelper do
   end
 
   describe '#link_to_schedule_once_visit' do
+    before do
+      helper.define_singleton_method(:patron_or_group, -> {}) # Define the helper we want to stub
+      allow(helper).to receive(:patron_or_group).and_return(
+        Patron.new('fields' => { 'profile' => { 'key' => 'MXF' } })
+      )
+    end
+
     it 'is a link with the appropriate data attributes' do
-      link = link_to_schedule_once_visit(library: 'GREEN', text: 'Green Library')
+      link = helper.link_to_schedule_once_visit(library: 'GREEN', text: 'Green Library')
       expect(link).to include 'data-mylibrary-modal="trigger"'
     end
 
     it 'links to the appropriate href given the library' do
-      link = link_to_schedule_once_visit(library: 'EAST-ASIA', text: 'East Asia Library')
+      link = helper.link_to_schedule_once_visit(library: 'EAST-ASIA', text: 'East Asia Library')
       expect(link).to include 'href="/schedule/eal"'
     end
 
     it 'uses the given text as the link text' do
-      link = Capybara.string(link_to_schedule_once_visit(library: 'GREEN', text: 'Green Library'))
+      link = Capybara.string(helper.link_to_schedule_once_visit(library: 'GREEN', text: 'Green Library'))
       expect(link).to have_link('Green Library', href: '/schedule/green')
+    end
+  end
+
+  describe '#schedule_once_link_or_dropdown' do
+    before do
+      helper.define_singleton_method(:patron_or_group, -> {}) # Define the helper we want to stub
+      allow(helper).to receive(:patron_or_group).and_return(patron)
+    end
+
+    context 'when the patron has no library access' do
+      let(:patron) { Patron.new({ 'fields' => {} }) }
+
+      it 'renders text indicating that the user is not eligible' do
+        expect(helper.schedule_once_link_or_dropdown).to eq 'Not eligible during current phase of Research Restart Plan'
+      end
+    end
+
+    context 'when the user has access to one library' do
+      let(:patron) { Patron.new('fields' => { 'profile' => { 'key' => 'MXF' } }) }
+
+      before do
+        allow(Settings.schedule_once.eal_visits).to receive(:enabled).and_return(false)
+      end
+
+      it 'renders a single button to schedule a visit' do
+        expect(
+          Capybara.string(helper.schedule_once_link_or_dropdown)
+        ).to have_link('🗓 Schedule access to Green Library', href: '/schedule/green')
+      end
+    end
+
+    context 'when the user has access to multiple libraries' do
+      let(:patron) { Patron.new('fields' => { 'profile' => { 'key' => 'MXF' } }) }
+      let(:dropdown) { Capybara.string(helper.schedule_once_link_or_dropdown) }
+
+      it 'renders a dropdown to select each library' do
+        expect(dropdown).to have_css('.schedule-once-dropdown button.dropdown-toggle', text: '🗓 Schedule access to ...')
+      end
+
+      it 'renders a link in the dropdown to Green Library' do
+        expect(dropdown).to have_css('.schedule-once-dropdown .dropdown-menu a', text: 'Green Library')
+      end
+
+      it 'renders a link in the dropdown to East Asia Library' do
+        expect(dropdown).to have_css('.schedule-once-dropdown .dropdown-menu a', text: 'East Asia Library')
+      end
     end
   end
 end

--- a/spec/helpers/summaries_helper_spec.rb
+++ b/spec/helpers/summaries_helper_spec.rb
@@ -10,4 +10,21 @@ RSpec.describe SummariesHelper do
       ).to eq 'blah=Jane%20Stanford&other_blah=Hello%40example.com'
     end
   end
+
+  describe '#link_to_schedule_once_visit' do
+    it 'is a link with the appropriate data attributes' do
+      link = link_to_schedule_once_visit(library: 'GREEN', text: 'Green Library')
+      expect(link).to include 'data-mylibrary-modal="trigger"'
+    end
+
+    it 'links to the appropriate href given the library' do
+      link = link_to_schedule_once_visit(library: 'EAST-ASIA', text: 'East Asia Library')
+      expect(link).to include 'href="/schedule/eal"'
+    end
+
+    it 'uses the given text as the link text' do
+      link = Capybara.string(link_to_schedule_once_visit(library: 'GREEN', text: 'Green Library'))
+      expect(link).to have_link('Green Library', href: '/schedule/green')
+    end
+  end
 end

--- a/spec/models/patron_spec.rb
+++ b/spec/models/patron_spec.rb
@@ -556,6 +556,38 @@ RSpec.describe Patron do
     end
   end
 
+  describe '#can_schedule_eal_access?' do
+    context 'with a user that should get access (faculty)' do
+      before do
+        fields[:profile]['key'] = 'MXF'
+      end
+
+      it { expect(patron.can_schedule_eal_access?).to eq true }
+    end
+
+    context 'with a user that should get access (fellow)' do
+      before do
+        fields[:profile]['key'] = 'CNAC'
+        fields[:customInformation] = [
+          { 'fields' => { 'code' => { 'key' => 'AFFIL1' }, 'data' => 'affiliate:fellow' } }
+        ]
+      end
+
+      it { expect(patron.can_schedule_eal_access?).to eq true }
+    end
+
+    context 'with a user that that should not get access (non-fellow)' do
+      before do
+        fields[:profile]['key'] = 'CNAC'
+        fields[:customInformation] = [
+          { 'fields' => { 'code' => { 'key' => 'AFFIL1' }, 'data' => 'staff' } }
+        ]
+      end
+
+      it { expect(patron.can_schedule_eal_access?).to eq false }
+    end
+  end
+
   describe '#to_partial_path' do
     context 'when expired' do
       before do

--- a/spec/views/summaries/index.html.erb_spec.rb
+++ b/spec/views/summaries/index.html.erb_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe 'summaries/index.html.erb' do
       remaining_checkouts: nil,
       to_partial_path: 'patron/patron',
       can_renew?: true,
+      can_schedule_eal_access?: false,
       can_schedule_green_access?: false,
       can_schedule_green_pickup?: false,
       can_schedule_special_collections_visit?: false,


### PR DESCRIPTION
... access to multiple libraries

Connected to #557 

### TODO
- [x] Update `routes.rb` with appropriate `oncehub_id` for EAL visits

## One library available/configured
<img width="697" alt="with only one library available/configured" src="https://user-images.githubusercontent.com/96776/84829566-d1751a80-afdc-11ea-856f-8326a26349f4.png">

## Multiple libraries available/configured
<img width="781" alt="with multiple libraries available/configured" src="https://user-images.githubusercontent.com/96776/84829570-d3d77480-afdc-11ea-8bf0-1ab8bb94ff10.png">
