### PR TITLE
Remove renewal eligibility for items with Item Cat5 of "NORENEW" 

### DIFF
--- a/app/controllers/renewals_controller.rb
+++ b/app/controllers/renewals_controller.rb
@@ -59,10 +59,15 @@ class RenewalsController < ApplicationController
     params.require(%I[resource item_key])
   end
 
+  # Make sure the checkout belongs to the user trying to do the renewal, and
+  # also make sure the item is not renewable for reasons that symphony doesn't
+  # know about (e.g. the itemCat5 hack we're doing during COVID-19 times; other
+  # conditions are handled by business logic in Symphony so we don't need to
+  # worry about being exhaustive here.)
   def authorize_update!
-    return if patron_or_group.checkouts.any? { |request| request.item_key == params.require(:item_key) }
+    checkout = patron_or_group.checkouts.find { |request| request.item_key == params.require(:item_key) }
 
-    raise CheckoutException, 'Error'
+    raise CheckoutException, 'Error' if checkout.nil? || checkout.item_category_non_renewable?
   end
 
   def deny_access

--- a/app/models/checkout.rb
+++ b/app/models/checkout.rb
@@ -63,7 +63,7 @@ class Checkout
     Time.zone.parse(fields['renewalDate']) if fields['renewalDate']
   end
 
-  # rubocop:disable Metrics/CyclomaticComplexity,Metrics/PerceivedComplexity
+  # rubocop:disable Metrics/CyclomaticComplexity,Metrics/PerceivedComplexity,Metrics/MethodLength
   def non_renewable_reason
     return 'Item is assumed lost; you must pay the fee or return the item.' if lost?
     return 'No. Another user is waiting for this item.' if recalled?
@@ -77,10 +77,15 @@ class Checkout
 
     return 'No renewals left for this item.' if seen_renewals_remaining.zero?
     return 'Renew Reserve items in person.' if reserve_item?
+    return 'No. Another user is waiting for this item.' if item_category_non_renewable?
 
     'Too soon to renew.' unless renewable_at&.past?
   end
-  # rubocop:enable Metrics/CyclomaticComplexity,Metrics/PerceivedComplexity
+  # rubocop:enable Metrics/CyclomaticComplexity,Metrics/PerceivedComplexity,Metrics/MethodLength
+
+  def item_category_non_renewable?
+    item.dig('itemCategory5', 'key') == 'NORENEW'
+  end
 
   def renewable?
     non_renewable_reason.blank?

--- a/app/services/symphony_client.rb
+++ b/app/services/symphony_client.rb
@@ -50,7 +50,7 @@ class SymphonyClient
     [
       "holdRecordList{*,#{ITEM_RESOURCES if item_details[:holdRecordList]}}",
       'circRecordList{*,circulationRule{loanPeriod{periodType{key}},renewFromPeriod},' \
-        "#{ITEM_RESOURCES if item_details[:circRecordList]}}",
+        "#{item_details[:circRecordList] ? ITEM_RESOURCES : 'item{itemCategory5}'}}",
       "blockList{*,#{ITEM_RESOURCES if item_details[:blockList]}}",
       'groupSettings{*,responsibility}'
     ]

--- a/spec/controllers/renewals_controller_spec.rb
+++ b/spec/controllers/renewals_controller_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe RenewalsController, type: :controller do
   end
 
   let(:mock_patron) { instance_double(Patron, checkouts: checkouts) }
-  let(:checkouts) { [instance_double(Checkout, item_key: '123')] }
+  let(:checkouts) { [instance_double(Checkout, item_key: '123', item_category_non_renewable?: false)] }
 
   before do
     warden.set_user(user)
@@ -74,6 +74,16 @@ RSpec.describe RenewalsController, type: :controller do
         post :create, params: { resource: 'abc', item_key: 'some_made_up_item_key' }
 
         expect(response).to redirect_to checkouts_path
+      end
+    end
+
+    context 'when the requested item is not eligible even though symphony does not stop us' do
+      let(:checkouts) { [instance_double(Checkout, item_key: '123', item_category_non_renewable?: true)] }
+
+      it 'does not renew the item and sets flash messages' do
+        post :create, params: { resource: 'abc', item_key: '123' }
+
+        expect(flash[:error]).to match('An unexpected error has occurred')
       end
     end
   end

--- a/spec/models/checkout_spec.rb
+++ b/spec/models/checkout_spec.rb
@@ -203,6 +203,28 @@ RSpec.describe Checkout do
     end
   end
 
+  context 'with a record with *an item* that is not renewable' do
+    before do
+      fields[:item][:fields][:itemCategory5] = { resource: 'foobar', key: 'NORENEW' }
+      fields['circulationRule'] = {
+        fields: {
+          renewFromPeriod: 999_999
+        }
+      }
+      fields['unseenRenewalsRemaining'] = 1
+    end
+
+    it 'has a non-renewable status' do
+      expect(checkout).not_to be_renewable
+    end
+
+    describe '#non_renewable_reason' do
+      it 'gives a reason why it is not renewable' do
+        expect(checkout.non_renewable_reason).to match('No. Another user is waiting for this item')
+      end
+    end
+  end
+
   context 'with a record that has unseenRenewalsRemaining as 0' do
     before do
       fields['circulationRule'] = {

--- a/spec/services/symphony_client_spec.rb
+++ b/spec/services/symphony_client_spec.rb
@@ -96,6 +96,13 @@ RSpec.describe SymphonyClient do
       expect(client.patron_info('somepatronkey')).to include 'key' => 'somepatronkey'
     end
 
+    it 'requests the itemCategory5 details for checkouts' do
+      client.patron_info('somepatronkey', item_details: {})
+
+      expect(WebMock).to have_requested(:get, 'https://example.com/symws/user/patron/key/somepatronkey')
+        .with(query: hash_including(includeFields: match(/circRecordList{.*,item{itemCategory5}}/)))
+    end
+
     context 'when requesting item details' do
       it 'requests the item details for checkouts' do
         client.patron_info('somepatronkey', item_details: { circRecordList: true })


### PR DESCRIPTION
Fixes #649.

This PR adds a new condition to stop patrons from renewing items that are marked as `NORENEW`. It also adds additional authorization for this condition within the application because Symphony won't enforce it for us.