### PR TITLE
Address issue with deploying main branch, and http gem version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,8 @@ gem 'honeybadger'
 
 gem 'config'
 
+# Until we upgrade to Rails 6, we cannot upgrade http to v.5.
+# See https://github.com/httprb/http/issues/673#issuecomment-859139518
 gem 'http', '~> 4.4'
 
 gem 'okcomputer'

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -2,6 +2,7 @@
 
 set :application, 'mylibrary'
 set :repo_url, 'git@github.com:sul-dlss/mylibrary.git'
+set :branch, 'main'
 
 # Default deploy_to directory is /var/www/my_app_name
 set :deploy_to, '/opt/app/mylibrary/mylibrary'


### PR DESCRIPTION
Hi @cbeer I was having a problem deploying to main without specifying the branch in the deploy script. Setting the remotes refs to main did not seem to help, and I am all out of ideas (except this PR). 

Also, there is an issue with the newer http gem version and Rails 5.2

Can you please review and offer any alternative suggestions you may have?