### PR TITLE
Use public client ID for patron pin reset requests

### DIFF
--- a/app/services/symphony_client.rb
+++ b/app/services/symphony_client.rb
@@ -121,10 +121,12 @@ class SymphonyClient
   end
 
   def change_pin(token, pin)
-    request('/user/patron/changeMyPin', method: :post, json: {
-      resetPinToken: token,
-      newPin: pin
-    })
+    request(
+      '/user/patron/changeMyPin',
+      method: :post,
+      json: { resetPinToken: token, newPin: pin },
+      headers: { 'x-sirs-clientID': Settings.symws.public_clientID }
+    )
   end
 
   def renew_item(resource, item_key)

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -5,6 +5,7 @@ symws:
   url:
   headers: {}
   login_params: {}
+  public_clientID:
 sw:
   url: https://searchworks.stanford.edu/view/
 EMAIL_TO: yolo@example.com


### PR DESCRIPTION
Fixes #678 
Associated shared configs PRs must be merged before deploying this.