### PR TITLE
Fix proxy tab styling.

### DIFF
--- a/app/assets/stylesheets/modules/navigation.scss
+++ b/app/assets/stylesheets/modules/navigation.scss
@@ -37,3 +37,9 @@
     }
   }
 }
+
+.proxy-tabs {
+  li {
+    font-size: $h3-font-size;
+  }
+}

--- a/app/views/shared/_group_tabs.html.erb
+++ b/app/views/shared/_group_tabs.html.erb
@@ -1,12 +1,12 @@
-<nav class="container" aria-label="Proxy tabs">
+<nav class="container proxy-tabs" aria-label="Proxy tabs">
   <ul class="nav nav-tabs nav-justified col-12 pt-3">
-    <li class="nav-item h3">
+    <li class="nav-item">
       <%= link_to url_for(group: nil), class: "nav-link #{params[:group].nil? && 'active'} p-3 mt-3", aria: { current: params[:group].nil? } do %>
         <%= patron_or_group.proxy_borrower? ? "Proxy #{patron_or_group.display_name}" : 'Self' %>
         <%= "(#{self_value})" if defined?(self_value) %>
       <% end %>
     </li>
-    <li class="nav-item h3">
+    <li class="nav-item">
       <%= link_to url_for(group: true), class: "nav-link #{params[:group] && 'active'} p-3 mt-3", aria: { current: params[:group] } do %>
         <%= patron.sponsor? ? 'Proxies' : 'Other proxies' %>
         <%= "(#{group_value})" if defined?(group_value) %>


### PR DESCRIPTION
The `h3` class was bringing more to the party than we wanted so I've adjusted the tab links to apply the h3 font size without the additional h3 styling.

<img width="1172" alt="Screen Shot 2022-01-11 at 2 39 06 PM" src="https://user-images.githubusercontent.com/458247/149010235-eb3ccd71-6958-4d8c-8dab-b2884e49e513.png">


Closes #679 