### PR TITLE
Implement BorrowDirect ReShare requests list for patron.

### DIFF
--- a/app/models/borrow_direct_reshare_requests.rb
+++ b/app/models/borrow_direct_reshare_requests.rb
@@ -1,0 +1,120 @@
+# frozen_string_literal: true
+
+class BorrowDirectReshareRequests
+  attr_reader :patron
+
+  def initialize(patron)
+    @patron = patron
+  end
+
+  def requests
+    # Ensure ReShare requests are active (not yet in Symphony)
+    # and that each ReShare request object's patron_id matches
+    # the logged in patron's university_id.
+    reshare_requests.select(&:active?)
+                    .select { |request| request.patron_id == patron.university_id }
+  end
+
+  private
+
+  def reshare_requests
+    return [] unless patron.university_id
+
+    request_client.requests(patron.university_id).map do |request|
+      ReshareRequest.new(request)
+    end
+  end
+
+  def request_client
+    @request_client ||= BorrowDirectReshareClient.new
+  end
+
+  ##
+  # Wrap the borrow direct reshare request item JSON in a class
+  # so we can give it a similar interface to Symphony Requests
+  class ReshareRequest
+    def initialize(request_json = [])
+      @request_json = request_json
+    end
+
+    # Request becomes REQ_CHECKED_IN once we receive it (and should show as a request ready for pickup/checkout)
+    # Request becomes REQ_REQUEST_COMPLETE once the uesr returns it
+    ACTIVE_REQUEST_STATUSES = %w[
+      REQ_IDLE
+      REQ_VALIDATED
+      REQ_SOURCING_ITEM
+      REQ_SUPPLIER_IDENTIFIED
+      REQ_REQUEST_SENT_TO_SUPPLIER
+      REQ_BORROWING_LIBRARY_RECEIVED
+      REQ_SHIPPED
+      REQ_ERROR
+      REQ_END_OF_ROTA
+      REQ_INVALID_PATRON
+      REQ_EXPECTS_TO_SUPPLY
+      REQ_CONDITIONAL_ANSWER_RECEIVED
+      REQ_CANCEL_PENDING
+      REQ_CANCELLED_WITH_SUPPLIER
+      REQ_CANCELLED
+      REQ_UNFILLED
+      REQ_LOCAL_REVIEW
+      REQ_FILLED_LOCALLY
+      REQ_UNABLE_TO_CONTACT_SUPPLIER
+    ].freeze
+
+    def active?
+      ACTIVE_REQUEST_STATUSES.include?(request_status)
+    end
+
+    def cdl_checkedout?
+      false
+    end
+
+    def date_submitted
+      Date.parse(@request_json.fetch('dateCreated', nil))
+    rescue TypeError, Date::Error => e
+      Honeybadger.notify(e)
+      nil
+    end
+
+    def expiration_date; end
+
+    def fill_by_date; end
+
+    def key
+      @request_json.fetch('id', nil)
+    end
+
+    def patron_id
+      @request_json.fetch('patronIdentifier', nil)
+    end
+
+    def pickup_library; end
+
+    def ready_for_pickup?
+      false
+    end
+
+    def request_status
+      @request_json.dig('state', 'code')
+    end
+
+    def sort_key(sort)
+      case sort
+      when :title
+        title
+      when :date
+        [::Request::END_OF_DAYS.strftime('%FT%T'), title].join('---')
+      else
+        ''
+      end
+    end
+
+    def title
+      @request_json.fetch('title', nil)
+    end
+
+    def to_partial_path
+      'requests/borrow_direct_request'
+    end
+  end
+end

--- a/app/models/patron.rb
+++ b/app/models/patron.rb
@@ -34,6 +34,10 @@ class Patron
     record['fields']['barcode']
   end
 
+  def university_id
+    record.dig('fields', 'alternateID')
+  end
+
   def status
     if expired?
       'Expired'
@@ -231,7 +235,11 @@ class Patron
   def borrow_direct_requests
     return [] if proxy_borrower? # Proxies can't submit borrow direct requests, so don't check.
 
-    BorrowDirectRequests.new(self).requests
+    if Settings.borrow_direct_reshare.enabled
+      BorrowDirectReshareRequests.new(self).requests
+    else
+      BorrowDirectRequests.new(self).requests
+    end
   end
 
   def symphony_requests

--- a/app/services/borrow_direct_reshare_client.rb
+++ b/app/services/borrow_direct_reshare_client.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require 'http'
+
+class BorrowDirectReshareClient
+  DEFAULT_HEADERS = {
+    accept: 'application/json, text/plain',
+    content_type: 'application/json'
+  }.freeze
+
+  attr_reader :base_url
+
+  def initialize(url: Settings.borrow_direct_reshare.url,
+                 username: Settings.borrow_direct_reshare.username,
+                 password: Settings.borrow_direct_reshare.password,
+                 tenant: Settings.borrow_direct_reshare.tenant)
+
+    @base_url = url
+    @username = username
+    @password = password
+    @tenant = tenant
+  end
+
+  def get(path, **kwargs)
+    authenticated_request(path, method: :get, **kwargs)
+  end
+
+  def get_json(path, **kwargs)
+    parse(get(path, **kwargs))
+  end
+
+  def requests(university_id)
+    get_json('/rs/patronrequests', params:
+      { filters: ['state.stage=ACTIVE', 'isRequester=true'],
+        match: 'patronIdentifier',
+        perPage: 100,
+        sort: 'dateCreated;desc',
+        term: university_id }) || []
+  end
+
+  def ping
+    session_token.present?
+  rescue HTTP::Error
+    false
+  end
+
+  private
+
+  def parse(response)
+    return nil if !response || response.body.empty?
+
+    JSON.parse(response.body)
+  rescue JSON::ParserError => e
+    Honeybadger.notify(e)
+  end
+
+  def session_token
+    @session_token ||= begin
+      response = request('/authn/login', json: { username: @username, password: @password }, method: :post)
+      response ? response['x-okapi-token'] : nil
+    end
+  end
+
+  def authenticated_request(path, headers: {}, **other)
+    request(path, headers: headers.merge('x-okapi-token': session_token), **other)
+  end
+
+  def request(path, headers: {}, method: :get, **other)
+    HTTP.headers(default_headers.merge(headers))
+        .request(method, base_url + path, **other)
+  end
+
+  def default_headers
+    DEFAULT_HEADERS.merge({ 'X-Okapi-Tenant': @tenant, 'User-Agent': 'ReShareApiClient' })
+  end
+end

--- a/app/views/requests/_borrow_direct_request.html.erb
+++ b/app/views/requests/_borrow_direct_request.html.erb
@@ -23,7 +23,7 @@
   <div class="collapse w-100" id="collapseDetails-<%= borrow_direct_request.key.parameterize %>">
     <dl class="row mb-0">
       <dt class="col-3 offset-1 col-md-2 offset-md-2">Requested:</dt>
-      <dd class="col-8"><%= l(borrow_direct_request.date_submitted, format: :short) %></dd>
+      <dd class="col-8"><%= l(borrow_direct_request.date_submitted, format: :short) if borrow_direct_request.date_submitted %></dd>
       <dt class="col-3 offset-1 col-md-2 offset-md-2">Source:</dt>
       <dd class="col-8">BorrowDirect</dd>
     </dl>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -27,6 +27,9 @@ symphony:
   host:
   override: PASSWORD
 
+borrow_direct_reshare:
+  enabled: false
+
 BORROW_DIRECT_CODE: BORROW_DIRECT
 ILL_CODE: ILL
 

--- a/spec/models/borrow_direct_reshare_requests_spec.rb
+++ b/spec/models/borrow_direct_reshare_requests_spec.rb
@@ -1,0 +1,149 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe BorrowDirectReshareRequests do
+  subject(:bd_requests) { described_class.new(patron) }
+
+  let(:patron) { instance_double(Patron, barcode: '123456', university_id: '12345678') }
+
+  let(:in_process_request) do
+    { 'id' => '11111111',
+      'state' => { 'code' => 'REQ_SHIPPED' },
+      'patronIdentifier' => '12345678',
+      'title' => 'A title',
+      'dateCreated' => '2022-12-05' }
+  end
+
+  let(:completed_request) do
+    { 'state' => { 'code' => 'REQ_REQUEST_COMPLETE' }, 'patronIdentifier' => '12345678' }
+  end
+
+  let(:request_client) do
+    instance_double(BorrowDirectReshareClient)
+  end
+
+  before { allow(BorrowDirectReshareClient).to receive(:new).and_return(request_client) }
+
+  context 'when successful' do
+    before do
+      allow(request_client).to receive(:requests).with(patron.university_id)
+                                                 .and_return([in_process_request, completed_request])
+    end
+
+    it 'only return requests with active statuses' do
+      expect(bd_requests.requests.length).to be(1)
+    end
+  end
+
+  context 'when the Patron university_id does not match the patron_id in the response' do
+    let(:request_with_wrong_patron) do
+      { 'state' => { 'code' => 'REQ_SHIPPED' }, 'patronIdentifier' => '7777777' }
+    end
+
+    before do
+      allow(request_client).to receive(:requests).with(patron.university_id)
+                                                 .and_return([request_with_wrong_patron])
+    end
+
+    it 'only return requests for the current patron' do
+      expect(bd_requests.requests.length).to be(0)
+    end
+  end
+
+  context 'when the patron does not have a university_id' do
+    let(:patron) { instance_double(Patron, barcode: '123456', university_id: nil) }
+
+    it 'returns an empty array' do
+      expect(bd_requests.requests).to eq([])
+    end
+  end
+
+  describe 'BorrowDirectReshareRequests::ReshareRequest' do
+    let(:request) do
+      BorrowDirectReshareRequests::ReshareRequest.new(in_process_request)
+    end
+
+    context 'when in an active state' do
+      it { expect(request).to be_active }
+    end
+
+    context 'when not in an active state' do
+      let(:request) do
+        BorrowDirectReshareRequests::ReshareRequest.new(completed_request)
+      end
+
+      it { expect(request).not_to be_active }
+    end
+
+    it { expect(request).not_to be_cdl_checkedout }
+
+    it 'returns the dateCreated as the date_submitted' do
+      expect(request.date_submitted.to_s).to eq '2022-12-05'
+    end
+
+    context 'when dateCreated value is missing' do
+      let(:request) do
+        BorrowDirectReshareRequests::ReshareRequest.new('id' => '00000000')
+      end
+
+      it 'date_submitted is nil' do
+        expect(request.date_submitted).to be_nil
+      end
+    end
+
+    context 'when dateCreated value is not parseable as a date' do
+      let(:request) do
+        BorrowDirectReshareRequests::ReshareRequest.new('dateCreated' => 'some string')
+      end
+
+      it 'date_submitted is nil' do
+        expect(request.date_submitted).to be_nil
+      end
+    end
+
+    it 'always returns nil for expiration_date' do
+      expect(request.expiration_date).to be_nil
+    end
+
+    it 'always returns nil for fill_by_date' do
+      expect(request.fill_by_date).to be_nil
+    end
+
+    it 'returns the request id as the key' do
+      expect(request.key).to eq '11111111'
+    end
+
+    it 'returns the patronIdentifier as the patron_id' do
+      expect(request.patron_id).to eq '12345678'
+    end
+
+    it 'always returns nil for pickup_library' do
+      expect(request.pickup_library).to be_nil
+    end
+
+    it { expect(request).not_to be_ready_for_pickup }
+
+    it 'returns the state code as the request_status' do
+      expect(request.request_status).to eq 'REQ_SHIPPED'
+    end
+
+    describe '#sort_key' do
+      context 'when title' do
+        it { expect(request.sort_key(:title)).to eq 'A title' }
+      end
+
+      context 'when date' do
+        it { expect(request.sort_key(:date)).to eq "#{Request::END_OF_DAYS.strftime('%FT%T')}---A title" }
+      end
+
+      context 'when any other sort value' do
+        it { expect(request.sort_key(:something_else)).to eq '' }
+      end
+    end
+
+    it 'returns the title' do
+      expect(request.title).to eq 'A title'
+    end
+  end
+end

--- a/spec/services/borrow_direct_reshare_client_spec.rb
+++ b/spec/services/borrow_direct_reshare_client_spec.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+RSpec.describe BorrowDirectReshareClient do
+  subject(:client) { described_class.new(url: url) }
+
+  let(:url) { 'https://example.com' }
+  let(:request_headers) do
+    {
+      'Accept' => 'application/json, text/plain',
+      'Connection' => 'close',
+      'Content-Type' => 'application/json',
+      'Host' => 'example.com',
+      'User-Agent' => 'ReShareApiClient',
+      'X-Okapi-Token' => 'tokentokentoken'
+    }
+  end
+
+  before do
+    stub_request(:post, 'https://example.com/authn/login')
+      .to_return(headers: { 'x-okapi-token': 'tokentokentoken' })
+  end
+
+  describe '#get' do
+    before do
+      stub_request(:get, 'https://example.com/blah')
+        .with(headers: request_headers)
+        .to_return(body: 'Hi!')
+    end
+
+    it 'sends a get request with okapi auth headers' do
+      expect(client.get('/blah').body.to_s).to eq('Hi!')
+    end
+
+    context 'with a method' do
+      before do
+        stub_request(:post, 'https://example.com/blah')
+          .with(headers: request_headers)
+          .to_return(body: 'Hi!')
+      end
+
+      it 'overrides the request type' do
+        expect(client.get('/blah', method: :post).body.to_s).to eq('Hi!')
+      end
+    end
+  end
+
+  describe '#get_json' do
+    before do
+      stub_request(:get, 'https://example.com/blah')
+        .to_return(body: body)
+    end
+
+    let(:body) { '{"hello": "world"}' }
+
+    it 'parses json responses into ruby objects' do
+      expect(client.get_json('/blah')).to eq('hello' => 'world')
+    end
+
+    describe 'when the response is empty' do
+      let(:body) { '' }
+
+      it 'returns nil' do
+        expect(client.get_json('/blah')).to be_nil
+      end
+    end
+  end
+
+  describe '#requests' do
+    before do
+      stub_request(:get, 'https://example.com/rs/patronrequests?filters=isRequester=true&' \
+                         'match=patronIdentifier&perPage=100&sort=dateCreated%3Bdesc&term=12345678')
+        .with(headers: request_headers)
+        .to_return(body: body)
+    end
+
+    let(:body) do
+      '[{"id": "00000000"}]'
+    end
+
+    it 'returns a list of requests' do
+      expect(client.requests('12345678')).to eq(['id' => '00000000'])
+    end
+  end
+end


### PR DESCRIPTION
BorrowDirect is changing back-end providers. This adds a client class for making requests to BorrowDirect reshare's new folio based system, a new request model to make the request for a patron's BorrowDirect requests, and wraps the response JSON in a class to mimic the Symphony request object behavior.

Closes #757 

Looks like (no design change from current implementation):

<img width="1165" alt="Screen Shot 2022-12-01 at 10 53 58 AM" src="https://user-images.githubusercontent.com/458247/205099155-8c92e8fe-0f27-4d19-9af6-ce1fd661807b.png">