### PR TITLE
Add rubocop-capybara to the require

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,5 @@
 require:
+  - rubocop-capybara
   - rubocop-performance
   - rubocop-rails
   - rubocop-rspec


### PR DESCRIPTION
This eliminates a warning when running rubocop:
```
The following RuboCop extension libraries are installed but not loaded in config:
  * rubocop-capybara
```