### PR TITLE
Rename action_cable to actioncable

### DIFF
--- a/app/assets/javascripts/cable.js
+++ b/app/assets/javascripts/cable.js
@@ -1,7 +1,7 @@
 // Action Cable provides the framework to deal with WebSockets in Rails.
 // You can generate new channels where WebSocket features live using the `rails generate channel` command.
 //
-//= require action_cable
+//= require actioncable
 //= require_self
 //= require_tree ./channels
 


### PR DESCRIPTION
The library has been renamed upstream and it currently issues a deprecation on the console when using the old name