### PR TITLE
Support resetting patron PINs using FOLIO APIs

### DIFF
--- a/app/controllers/reset_pins_controller.rb
+++ b/app/controllers/reset_pins_controller.rb
@@ -22,9 +22,10 @@ class ResetPinsController < ApplicationController
   def reset
     suppress ActiveRecord::RecordNotFound do
       ils_client.reset_pin(reset_pin_params, change_pin_with_token_unencoded_url)
-      flash[:success] = t 'mylibrary.reset_pin.success_html', library_id: params['library_id']
-      redirect_to login_path
     end
+
+    flash[:success] = t 'mylibrary.reset_pin.success_html', library_id: params['library_id']
+    redirect_to login_path
   end
 
   # Renders the third step for resetting a PIN, where we prompt the user

--- a/app/controllers/reset_pins_controller.rb
+++ b/app/controllers/reset_pins_controller.rb
@@ -3,34 +3,33 @@
 # Controller for reseting a Barcode+PIN user's PIN
 class ResetPinsController < ApplicationController
   before_action :logout_user!
+  rescue_from ActiveRecord::RecordNotFound, with: :user_not_found
+  rescue_from ActiveSupport::MessageEncryptor::InvalidMessage, with: :invalid_token
 
-  # Renders the first step for reseting the PIN
+  # Renders the first step for resetting the PIN
   #
   # GET /reset_pin
   def index; end
 
-  # Trigger a reset request for the PIN in Symphony; this will
-  # send the patron an email (using their email adddress on file)
+  # Trigger a reset request for the PIN; this will
+  # send the patron an email (using their email address on file)
   # with a link back to our change form and a token for completing the reset
   #
   # POST /reset_pin
   def reset
-    @response = ils_client.reset_pin(
-      params['library_id'],
-      change_pin_with_token_unencoded_url
-    )
+    @response = ils_client.reset_pin(reset_pin_params, change_pin_with_token_unencoded_url)
     flash[:success] = t 'mylibrary.reset_pin.success_html', library_id: params['library_id']
     render action: :index
   end
 
-  # Renders the third step for reseting a PIN, where we prompt the user
+  # Renders the third step for resetting a PIN, where we prompt the user
   # to enter a new pin
   #
   # GET /change_pin/:token
   def change_form; end
 
-  # Finally, trigger the PIN update in Symphony using the token the user
-  # received in their email and the new PIN the just entered
+  # Finally, trigger the PIN update in the ILS using the token the user
+  # received in their email and the new PIN they just entered
   #
   # POST /change_pin
   def change
@@ -41,21 +40,36 @@ class ResetPinsController < ApplicationController
       flash[:success] = t 'mylibrary.change_pin.success_html'
       redirect_to login_path
     else
-      flash[:error] = t 'mylibrary.change_pin.error_html'
+      flash[:error] = t 'mylibrary.change_pin.invalid_token_html'
       redirect_to reset_pin_path
     end
   end
 
   private
 
+  def reset_pin_params
+    params.require(:library_id)
+  end
+
   def change_pin_with_token_params
     params.require(%I[token pin])
+  end
+
+  def user_not_found
+    flash[:error] = t 'mylibrary.reset_pin.user_not_found_html'
+    redirect_to reset_pin_path
+  end
+
+  def invalid_token
+    flash[:error] = t 'mylibrary.change_pin.invalid_token_html'
+    redirect_to reset_pin_path
   end
 
   ##
   # Hacky workaround Rails routing helpers to have the <> not encoded
   # Symphony looks for the string <RESET_PIN_TOKEN> and injects the actual token
   # in a URL crafted in the email sent to the user.
+  # TODO: remove this once we move to FOLIO
   def change_pin_with_token_unencoded_url
     change_pin_with_token_url('foo').gsub('foo', '<RESET_PIN_TOKEN>')
   end

--- a/app/mailers/reset_pins_mailer.rb
+++ b/app/mailers/reset_pins_mailer.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# A mailer for sending PIN reset emails
+class ResetPinsMailer < ApplicationMailer
+  default from: 'sul-privileges@stanford.edu'
+
+  # Send an email with a link to change a patron's PIN
+  def reset_pin
+    @patron = params[:patron]
+    @url = change_pin_with_token_url(params[:token])
+
+    mail(
+      to: email_address_with_name(@patron.email, @patron.display_name),
+      subject: t('mylibrary.reset_pins_mailer.reset_pin.subject')
+    )
+  end
+end

--- a/app/services/folio_client.rb
+++ b/app/services/folio_client.rb
@@ -196,6 +196,9 @@ class FolioClient
   # @param [String] new_pin the new PIN to assign
   def change_pin(token, new_pin)
     patron_key = crypt.decrypt_and_verify(token)
+    # expired tokens evaluate to nil; we want to raise an error instead
+    raise ActiveSupport::MessageEncryptor::InvalidMessage unless patron_key
+
     response = post('/patron-pin', json: { id: patron_key, pin: new_pin })
     check_response(response, title: 'Assign pin', context: { user_id: patron_key, pin: new_pin })
   end

--- a/app/services/symphony_client.rb
+++ b/app/services/symphony_client.rb
@@ -2,6 +2,8 @@
 
 # HTTP client wrapper for making requests to Symws
 class SymphonyClient
+  class IlsError < StandardError; end
+
   DEFAULT_HEADERS = {
     accept: 'application/json',
     content_type: 'application/json'
@@ -116,17 +118,19 @@ class SymphonyClient
       login: library_id,
       resetPinUrl: reset_path
     })
+    raise IlsError, response.body unless response.status == 200
 
     JSON.parse(response.body)
   end
 
   def change_pin(token, pin)
-    request(
+    response = request(
       '/user/patron/changeMyPin',
       method: :post,
       json: { resetPinToken: token, newPin: pin },
       headers: { 'x-sirs-clientID': Settings.symws.public_clientID }
     )
+    raise IlsError, response.body unless response.status == 200
   end
 
   def renew_item(resource, item_key, _patron_key = nil)

--- a/app/views/reset_pins_mailer/reset_pin.html.erb
+++ b/app/views/reset_pins_mailer/reset_pin.html.erb
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  </head>
+  <body>
+    <p>
+      This email was sent in response to a request from My Library Account to
+      change the PIN for account <b><%= @patron.barcode %></b>.
+    </p>
+    <p style="font-size: 18pt">
+      <a href="<%= @url %>">Change my PIN</a>
+    </p>
+    <p>
+      If you did not ask to change your PIN, ignore this email. This link will
+      expire in 20 minutes.
+    </p>
+    <p>
+      Questions? Contact the Privileges desk at sul-privileges@stanford.edu or
+      (650) 723-1492.
+    </p>
+  </body>
+</html>

--- a/app/views/reset_pins_mailer/reset_pin.text.erb
+++ b/app/views/reset_pins_mailer/reset_pin.text.erb
@@ -1,0 +1,7 @@
+This email was sent in response to a request from My Library Account to change the PIN for account <%= @patron.barcode %>.
+
+To change your PIN, please use this link: <%= @url %>
+
+If you did not ask to change your PIN, ignore this email. This link will expire in 20 minutes.
+
+Questions? Contact the Privileges desk at sul-privileges@stanford.edu or (650) 723-1492.

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -43,6 +43,9 @@ Rails.application.configure do
 
   config.action_mailer.perform_caching = false
 
+  # Make sure URL helpers in emails work
+  config.action_mailer.default_url_options = { host: 'mylibrary-dev.stanford.edu' }
+
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -44,7 +44,7 @@ Rails.application.configure do
   config.action_mailer.perform_caching = false
 
   # Make sure URL helpers in emails work
-  config.action_mailer.default_url_options = { host: 'mylibrary-dev.stanford.edu' }
+  config.action_mailer.default_url_options = { host: Settings.mailer_host, port: 3000 }
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -66,6 +66,9 @@ Rails.application.configure do
 
   config.action_mailer.perform_caching = false
 
+  # Make sure URL helpers in emails work
+  config.action_mailer.default_url_options = { host: 'mylibrary.stanford.edu' }
+
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -67,7 +67,7 @@ Rails.application.configure do
   config.action_mailer.perform_caching = false
 
   # Make sure URL helpers in emails work
-  config.action_mailer.default_url_options = { host: 'mylibrary.stanford.edu' }
+  config.action_mailer.default_url_options = { host: Settings.mailer_host, protocol: 'https' }
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -45,6 +45,9 @@ Rails.application.configure do
   # ActionMailer::Base.deliveries array.
   config.action_mailer.delivery_method = :test
 
+  # Make sure URL helpers in emails work
+  config.action_mailer.default_url_options = { host: 'mylibrary-dev.stanford.edu' }
+
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -46,7 +46,7 @@ Rails.application.configure do
   config.action_mailer.delivery_method = :test
 
   # Make sure URL helpers in emails work
-  config.action_mailer.default_url_options = { host: 'mylibrary-dev.stanford.edu' }
+  config.action_mailer.default_url_options = { host: Settings.mailer_host, port: 3000 }
 
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -62,9 +62,13 @@ en:
       deny_access: An unexpected error has occurred
     change_pin:
       success_html: <span class="font-weight-bold">Success!</span> Your new PIN is ready to use.
-      error_html: <span class="font-weight-bold">Sorry!</span> That reset PIN link has expired or has already been used. Enter your library ID to request a new link.
+      invalid_token_html: <span class="font-weight-bold">Sorry!</span> That reset PIN link is invalid or expired. Enter your library ID to request a new link.
     reset_pin:
       success_html: <span class="font-weight-bold">Check your email!</span> A PIN reset link has been sent to the address associated with library ID %{library_id}
+      user_not_found_html: <span class="font-weight-bold">Sorry!</span> We couldn't find an account matching that library ID.
+    reset_pins_mailer:
+      reset_pin:
+        subject: Stanford Libraries PIN reset
     contact_form:
       success: Thank you! Library staff will be in touch with you soon.
     contact_mailer:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -65,7 +65,6 @@ en:
       invalid_token_html: <span class="font-weight-bold">Sorry!</span> That reset PIN link is invalid or expired. Enter your library ID to request a new link.
     reset_pin:
       success_html: <span class="font-weight-bold">Check your email!</span> A PIN reset link has been sent to the address associated with library ID %{library_id}
-      user_not_found_html: <span class="font-weight-bold">Sorry!</span> We couldn't find an account matching that library ID.
       request_failed_html: <span class="font-weight-bold">Sorry!</span> Something went wrong, possibly due to a connection failure. Try again or contact us for help.
     reset_pins_mailer:
       reset_pin:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -66,6 +66,7 @@ en:
     reset_pin:
       success_html: <span class="font-weight-bold">Check your email!</span> A PIN reset link has been sent to the address associated with library ID %{library_id}
       user_not_found_html: <span class="font-weight-bold">Sorry!</span> We couldn't find an account matching that library ID.
+      request_failed_html: <span class="font-weight-bold">Sorry!</span> Something went wrong, possibly due to a connection failure. Try again or contact us for help.
     reset_pins_mailer:
       reset_pin:
         subject: Stanford Libraries PIN reset

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -53,3 +53,5 @@ purl:
   url: https://purl.stanford.edu
 
 analytics_debug: true
+
+mailer_host: 'localhost'

--- a/spec/controllers/reset_pins_controller_spec.rb
+++ b/spec/controllers/reset_pins_controller_spec.rb
@@ -42,8 +42,7 @@ RSpec.describe ResetPinsController do
     end
 
     context 'when everything is good' do
-      let(:response) { instance_double('Response', status: 200, content_type: :json) }
-      let(:mock_client) { instance_double(SymphonyClient, change_pin: response, ping: true) }
+      let(:mock_client) { instance_double(SymphonyClient, change_pin: {}, ping: true) }
 
       it 'changes the pin and sets flash messages' do
         post :change, params: { token: 'abc', pin: '123' }
@@ -57,8 +56,9 @@ RSpec.describe ResetPinsController do
     end
 
     context 'when the response is not 200' do
-      let(:response) { instance_double('Response', status: 401, content_type: :json) }
-      let(:mock_client) { instance_double(SymphonyClient, change_pin: response, ping: true) }
+      before do
+        allow(mock_client).to receive(:change_pin).and_raise(SymphonyClient::IlsError)
+      end
 
       it 'does not change the pin and sets flash messages' do
         post :change, params: { token: 'abc', pin: '123' }

--- a/spec/features/reset_pin_spec.rb
+++ b/spec/features/reset_pin_spec.rb
@@ -14,7 +14,17 @@ RSpec.describe 'Reset Pin' do
     end
   end
 
-  context 'when logged out' do
+  context 'when using Symphony' do
+    let(:mock_client) { instance_double(SymphonyClient, ping: true) }
+
+    before do
+      allow(Settings.ils).to receive(:client).and_return('SymphonyClient')
+      allow(Settings.ils).to receive(:patron_model).and_return('Symphony::Patron')
+      allow(SymphonyClient).to receive(:new).and_return(mock_client)
+      allow(mock_client).to receive(:reset_pin).and_return(nil)
+      allow(mock_client).to receive(:change_pin).and_return(nil)
+    end
+
     it 'allows user to reset pin' do
       visit reset_pin_path
       fill_in('library_id', with: '123456')
@@ -27,6 +37,63 @@ RSpec.describe 'Reset Pin' do
       fill_in('pin', with: '123456')
       click_button 'Change PIN'
       expect(page).to have_css '.flash_messages', text: 'Success!'
+    end
+  end
+
+  context 'when using FOLIO' do
+    let(:client) { FolioClient.new(url: 'http://example.com') }
+    let(:mock_client) { instance_double(FolioClient, ping: true) }
+    let(:patron) do
+      instance_double(Folio::Patron, key: 'abcdefg123', barcode: '123456', email: 'jdoe@stanford.edu',
+                                     display_name: 'J Doe')
+    end
+
+    before do
+      allow(Settings.ils).to receive(:client).and_return('FolioClient')
+      allow(Settings.ils).to receive(:patron_model).and_return('Folio::Patron')
+      allow(FolioClient).to receive(:new).and_return(client)
+      allow(client).to receive(:session_token).and_return('token')
+      allow(client).to receive(:find_patron_by_barcode).with('123456').and_return(patron)
+    end
+
+    it 'sends the user an email that can be used to change their pin' do
+      visit reset_pin_path
+      fill_in('library_id', with: '123456')
+      click_button 'Reset/Request PIN'
+      mail = ActionMailer::Base.deliveries.last
+      token = mail.html_part.body.decoded.match(%r{change_pin/(.*?)">})[1]
+      visit change_pin_with_token_path(token)
+      fill_in('pin', with: 'newpin')
+      click_button 'Change PIN'
+      expect(page).to have_css '.flash_messages', text: 'Success!'
+    end
+
+    context 'when the token is invalid' do
+      before do
+        allow(FolioClient).to receive(:new).and_return(mock_client)
+        allow(mock_client).to receive(:change_pin).and_raise(ActiveSupport::MessageEncryptor::InvalidMessage)
+      end
+
+      it 'shows the user an error' do
+        visit change_pin_with_token_path('not_a_real_token')
+        fill_in('pin', with: 'newpin')
+        click_button 'Change PIN'
+        expect(page).to have_css '.flash_messages', text: 'invalid or expired'
+      end
+    end
+
+    context 'when asking the ILS to change the PIN fails' do
+      before do
+        allow(FolioClient).to receive(:new).and_return(mock_client)
+        allow(mock_client).to receive(:change_pin).and_raise(FolioClient::IlsError)
+      end
+
+      it 'shows the user an error' do
+        visit change_pin_with_token_path('foo')
+        fill_in('pin', with: 'newpin')
+        click_button 'Change PIN'
+        expect(page).to have_css '.flash_messages', text: 'Something went wrong'
+      end
     end
   end
 

--- a/spec/features/reset_pin_spec.rb
+++ b/spec/features/reset_pin_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe 'Reset Pin' do
     let(:mock_client) { instance_double(SymphonyClient, ping: true) }
 
     before do
-      allow(Settings.ils).to receive(:client).and_return('SymphonyClient')
+      allow(ApplicationController).to receive(:ils_client_class).and_return(SymphonyClient)
       allow(Settings.ils).to receive(:patron_model).and_return('Symphony::Patron')
       allow(SymphonyClient).to receive(:new).and_return(mock_client)
       allow(mock_client).to receive(:reset_pin).and_return(nil)
@@ -38,39 +38,61 @@ RSpec.describe 'Reset Pin' do
       click_button 'Change PIN'
       expect(page).to have_css '.flash_messages', text: 'Success!'
     end
+
+    context 'when asking the ILS to send the email fails' do
+      before do
+        allow(mock_client).to receive(:reset_pin).and_raise(SymphonyClient::IlsError)
+      end
+
+      it 'shows the user an error' do
+        visit reset_pin_path
+        fill_in('library_id', with: '123456')
+        click_button 'Reset/Request PIN'
+        expect(page).to have_css '.flash_messages', text: 'Something went wrong'
+      end
+    end
+
+    context 'when asking the ILS to change the PIN fails' do
+      before do
+        allow(mock_client).to receive(:change_pin).and_raise(SymphonyClient::IlsError)
+      end
+
+      it 'shows the user an error' do
+        visit change_pin_with_token_path('foo')
+        fill_in('pin', with: '123456')
+        click_button 'Change PIN'
+        expect(page).to have_css '.flash_messages', text: 'Something went wrong'
+      end
+    end
   end
 
   context 'when using FOLIO' do
-    let(:client) { FolioClient.new(url: 'http://example.com') }
     let(:mock_client) { instance_double(FolioClient, ping: true) }
-    let(:patron) do
-      instance_double(Folio::Patron, key: 'abcdefg123', barcode: '123456', email: 'jdoe@stanford.edu',
-                                     display_name: 'J Doe')
-    end
 
     before do
-      allow(Settings.ils).to receive(:client).and_return('FolioClient')
+      allow(ApplicationController).to receive(:ils_client_class).and_return(FolioClient)
       allow(Settings.ils).to receive(:patron_model).and_return('Folio::Patron')
-      allow(FolioClient).to receive(:new).and_return(client)
-      allow(client).to receive(:session_token).and_return('token')
-      allow(client).to receive(:find_patron_by_barcode).with('123456').and_return(patron)
+      allow(FolioClient).to receive(:new).and_return(mock_client)
+      allow(mock_client).to receive(:reset_pin).and_return(nil)
+      allow(mock_client).to receive(:change_pin).and_return(nil)
     end
 
-    it 'sends the user an email that can be used to change their pin' do
+    it 'allows user to reset pin' do
       visit reset_pin_path
       fill_in('library_id', with: '123456')
       click_button 'Reset/Request PIN'
-      mail = ActionMailer::Base.deliveries.last
-      token = mail.html_part.body.decoded.match(%r{change_pin/(.*?)">})[1]
-      visit change_pin_with_token_path(token)
-      fill_in('pin', with: 'newpin')
+      expect(page).to have_css '.flash_messages', text: 'Check your email!'
+    end
+
+    it 'a user can change their pin' do
+      visit change_pin_with_token_path('foo')
+      fill_in('pin', with: '123456')
       click_button 'Change PIN'
       expect(page).to have_css '.flash_messages', text: 'Success!'
     end
 
     context 'when the token is invalid' do
       before do
-        allow(FolioClient).to receive(:new).and_return(mock_client)
         allow(mock_client).to receive(:change_pin).and_raise(ActiveSupport::MessageEncryptor::InvalidMessage)
       end
 
@@ -84,7 +106,6 @@ RSpec.describe 'Reset Pin' do
 
     context 'when asking the ILS to change the PIN fails' do
       before do
-        allow(FolioClient).to receive(:new).and_return(mock_client)
         allow(mock_client).to receive(:change_pin).and_raise(FolioClient::IlsError)
       end
 

--- a/spec/mailers/previews/reset_pins_preview.rb
+++ b/spec/mailers/previews/reset_pins_preview.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# Preview all emails at http://localhost:3000/rails/mailers/reset_pin
+class ResetPinsPreview < ActionMailer::Preview
+  def reset_pin
+    ResetPinsMailer.with(
+      patron: preview_patron,
+      token: 'j3n+JOtqbo2KV8SGVZsZn/tjalSjaVSpOeDxuIQmEAVGSsk8O'
+    ).reset_pin
+  end
+
+  private
+
+  # An example patron record for testing PIN reset email appearance
+  def preview_patron
+    Folio::Patron.new('id' => '77052ede-7ded-4583-afcb-bc845b7eab80',
+                      'user' => {
+                        'barcode' => '2558563207',
+                        'personal' => {
+                          'firstName' => 'Jane',
+                          'lastName' => 'Doe',
+                          'email' => 'janedoe@stanford.edu'
+                        }
+                      })
+  end
+end

--- a/spec/mailers/reset_pins_mailer_spec.rb
+++ b/spec/mailers/reset_pins_mailer_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ResetPinsMailer do
+  describe '#reset_pin' do
+    subject(:mail) { described_class.with(patron: patron, token: token).reset_pin }
+
+    let(:patron) { instance_double(Folio::Patron, email: 'jdoe@stanford.edu', display_name: 'J Doe', barcode: '123') }
+    let(:token) { 'secret_token' }
+
+    it 'is sent to the patron using their email' do
+      expect(mail.to).to eq ['jdoe@stanford.edu']
+    end
+
+    it 'is sent from the SUL privileges desk' do
+      expect(mail.from).to eq ['sul-privileges@stanford.edu']
+    end
+
+    it 'includes a link to the change PIN form in the body' do
+      expect(mail.html_part.body).to have_link 'Change my PIN', href: change_pin_with_token_url(token)
+    end
+  end
+end


### PR DESCRIPTION
Closes #739

This implements a user flow where the patron can request that an
email be sent to them that includes a token, which can be used
to reset their PIN. Symphony generates this email, but for FOLIO
we need to generate and send it ourselves, including the token.

You can view a preview of what the email looks like by visiting
/rails/mailers/reset_pins/reset_pin. It's designed to look the
same as the ones Symphony generates currently.
