### PR TITLE
Handle case where renewals remaining is less than 0

### DIFF
--- a/app/models/folio/checkout.rb
+++ b/app/models/folio/checkout.rb
@@ -72,7 +72,7 @@ module Folio
       return 'No. Another user is waiting for this item.' if recalled?
       return 'No. Claim review is in process.' if claimed_returned?
 
-      if unseen_renewals_remaining.zero?
+      unless unseen_renewals_remaining.positive?
         return 'No online renewals left; you may renew this item in person.' if renewal_count.positive?
 
         return 'No online renewals for this item.'


### PR DESCRIPTION
Seems like since we're doing math to arrive at the renewals remaining count that it could be less than 0 under some conditions? Such as if there's a way for staff to override?