### PR TITLE
Add Folio::LoanPolicy class to wrap renewal logic

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -80,6 +80,7 @@ group :development, :test do
   gem 'rubocop-rspec'
   gem 'simplecov', require: false
   gem 'sinatra', require: false # used for faking the symphony api for integration tests
+  gem 'timecop'
   gem 'warden-rspec-rails'
   gem 'webdrivers'
   gem 'webmock'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -381,6 +381,7 @@ GEM
       net-ssh (>= 2.8.0)
     thor (1.2.2)
     tilt (2.2.0)
+    timecop (0.9.6)
     timeout (0.3.2)
     turbolinks (5.2.1)
       turbolinks-source (~> 5.2)
@@ -457,6 +458,7 @@ DEPENDENCIES
   sinatra
   sprockets-rails
   sqlite3 (~> 1.4)
+  timecop
   turbolinks (~> 5)
   tzinfo-data
   warden

--- a/app/models/folio/loan_policy.rb
+++ b/app/models/folio/loan_policy.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+module Folio
+  class LoanPolicy
+    attr_reader :loan_policy, :due_date
+
+    def initialize(loan_policy:, due_date:)
+      @loan_policy = loan_policy
+      @due_date = due_date
+    end
+
+    # Renewing would not extend the due date
+    def too_soon_to_renew?
+      due_date_after_renewal <= due_date
+    end
+
+    private
+
+    def due_date_after_renewal
+      if schedule_policy
+        due_date_from_schedule
+      elsif renewal_calculated_from_system_date?
+        Time.zone.now + renewal_duration
+      elsif renewal_calculated_from_due_date?
+        due_date + renewal_duration
+      end
+    end
+
+    def due_date_from_schedule
+      schedule = schedule_policy.find do |policy|
+        Time.zone.now.between?(policy['from'], policy['to'])
+      end
+
+      schedule['due'] if schedule
+    end
+
+    def schedule_policy
+      effective_loan_policy_schedule&.map do |schedule|
+        schedule.transform_values { |v| Date.parse(v) }
+      end
+    end
+
+    def effective_loan_policy_schedule
+      renewal_policy_schedule || loan_policy_schedule
+    end
+
+    def loan_policy_schedule
+      loan_policy.dig('loansPolicy', 'fixedDueDateSchedule', 'schedules')
+    end
+
+    def renewal_policy_schedule
+      loan_policy.dig('renewalsPolicy', 'alternateFixedDueDateSchedule', 'schedules')
+    end
+
+    def renewal_calculated_from_system_date?
+      loan_policy.dig('renewalsPolicy', 'renewFromId') == 'SYSTEM_DATE'
+    end
+
+    def renewal_calculated_from_due_date?
+      loan_policy.dig('renewalsPolicy', 'renewFromId') == 'CURRENT_DUE_DATE'
+    end
+
+    # rubocop:disable Metrics/MethodLength
+    def renewal_duration
+      case effective_policy_interval
+      when 'Months'
+        effective_policy_duration.months
+      when 'Weeks'
+        effective_policy_duration.weeks
+      when 'Days'
+        effective_policy_duration.days
+      when 'Hours'
+        effective_policy_duration.hours
+      when 'Minutes'
+        effective_policy_duration.minutes
+      end
+    end
+    # rubocop:enable Metrics/MethodLength
+
+    def effective_policy_interval
+      renewals_policy_interval || loan_policy_interval
+    end
+
+    def effective_policy_duration
+      renewals_policy_duration || loan_policy_duration
+    end
+
+    def renewals_policy_interval
+      loan_policy.dig('renewalsPolicy', 'period', 'intervalId')
+    end
+
+    def renewals_policy_duration
+      loan_policy.dig('renewalsPolicy', 'period', 'duration')
+    end
+
+    def loan_policy_interval
+      loan_policy.dig('loansPolicy', 'period', 'intervalId')
+    end
+
+    def loan_policy_duration
+      loan_policy.dig('loansPolicy', 'period', 'duration')
+    end
+  end
+end

--- a/app/services/folio_graphql_client.rb
+++ b/app/services/folio_graphql_client.rb
@@ -234,12 +234,32 @@ class FolioGraphqlClient
                 description
                 renewable
                 renewalsPolicy {
+                  alternateFixedDueDateSchedule {
+                    schedules {
+                      due
+                      from
+                      to
+                    }
+                  }
                   numberAllowed
+                  period {
+                    intervalId
+                    duration
+                  }
+                  renewFromId
                   unlimited
                 }
                 loansPolicy {
+                  fixedDueDateSchedule {
+                    schedules {
+                      due
+                      from
+                      to
+                    }
+                  }
                   period {
                     intervalId
+                    duration
                   }
                 }
               }

--- a/spec/models/folio/loan_policy_spec.rb
+++ b/spec/models/folio/loan_policy_spec.rb
@@ -1,0 +1,149 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Folio::LoanPolicy do
+  subject(:folio_loan_policy) do
+    described_class.new(loan_policy: loan_policy, due_date: due_date)
+  end
+
+  before do
+    Timecop.freeze(Time.zone.local(2023, 6, 20, 7, 24, 2))
+  end
+
+  after do
+    Timecop.return
+  end
+
+  describe '#too_soon_to_renew?' do
+    describe 'schedule loan policy' do
+      let(:loan_policy) do
+        { 'loansPolicy' =>
+           { 'fixedDueDateSchedule' => { 'description' => 'Annual loans',
+                                         'id' => '277410e1-2908-4e2b-bf96-ac81b4aedad4',
+                                         'name' => 'Annual due date schedule',
+                                         'schedules' =>
+            [{ 'due' => '2023-07-01T06:59:59.000+00:00',
+               'from' => '1993-02-01T08:00:00.000+00:00',
+               'to' => '2023-05-01T06:59:59.000+00:00' },
+             { 'due' => '2024-07-02T06:59:59.000+00:00',
+               'from' => '2023-05-01T07:00:00.000+00:00',
+               'to' => '2024-05-01T06:59:59.000+00:00' }] },
+             'period' => nil },
+          'renewalsPolicy' =>
+           { 'renewFromId' => nil,
+             'period' => nil,
+             'alternateFixedDueDateSchedule' => nil } }
+      end
+
+      context 'when renewal would not extend the due date' do
+        let(:due_date) { Date.parse('2024-07-02T06:59:59.000+00:00') }
+
+        it { expect(folio_loan_policy.too_soon_to_renew?).to be true }
+      end
+
+      context 'when renewal would extend the due date' do
+        let(:due_date) { Date.parse('2023-07-02T06:59:59.000+00:00') }
+
+        it { expect(folio_loan_policy.too_soon_to_renew?).to be false }
+      end
+    end
+
+    describe 'alternate schedule loan policy' do
+      let(:loan_policy) do
+        { 'loansPolicy' =>
+           { 'fixedDueDateSchedule' => { 'description' => 'Annual loans',
+                                         'id' => '277410e1-2908-4e2b-bf96-ac81b4aedad4',
+                                         'name' => 'Annual due date schedule',
+                                         'schedules' =>
+            [{ 'due' => '2023-07-01T06:59:59.000+00:00',
+               'from' => '1993-02-01T08:00:00.000+00:00',
+               'to' => '2023-05-01T06:59:59.000+00:00' },
+             { 'due' => '2024-07-02T06:59:59.000+00:00',
+               'from' => '2023-05-01T07:00:00.000+00:00',
+               'to' => '2024-05-01T06:59:59.000+00:00' }] },
+             'period' => nil },
+          'renewalsPolicy' =>
+           { 'renewFromId' => nil,
+             'period' => nil,
+             'alternateFixedDueDateSchedule' => { 'description' => 'Alternate annual loans',
+                                                  'id' => '277410e1-2908-4e2b-bf96-ac81b4aedad4',
+                                                  'name' => 'Annual due date schedule',
+                                                  'schedules' =>
+              [{ 'due' => '2004-07-02T06:59:59.000+00:00',
+                 'from' => '2003-05-01T07:00:00.000+00:00',
+                 'to' => '2004-05-01T06:59:59.000+00:00' }] } } }
+      end
+
+      # NOTE: Setting the current time further in the past so it falls
+      #       within the range of the alternate schedule.
+      before do
+        Timecop.freeze(Time.zone.local(2003, 6, 20, 7, 24, 2))
+      end
+
+      context 'when renewal would extend the due date' do
+        let(:due_date) { Date.parse('2003-07-02T06:59:59.000+00:00') }
+
+        it { expect(folio_loan_policy.too_soon_to_renew?).to be false }
+      end
+    end
+
+    describe 'period loan policy where renewal is calculated from the current time' do
+      let(:loan_policy) do
+        { 'loansPolicy' =>
+          { 'fixedDueDateSchedule' => nil,
+            'period' => { 'intervalId' => 'Weeks', 'duration' => 20 } },
+          'renewalsPolicy' =>
+          { 'renewFromId' => 'SYSTEM_DATE',
+            'period' => nil,
+            'alternateFixedDueDateSchedule' => nil } }
+      end
+
+      context 'when renewal would not extend the due date' do
+        let(:due_date) { Date.parse('2024-07-02T06:59:59.000+00:00') }
+
+        it { expect(folio_loan_policy.too_soon_to_renew?).to be true }
+      end
+
+      context 'when renewal would extend the due date' do
+        let(:due_date) { Date.parse('2023-07-02T06:59:59.000+00:00') }
+
+        it { expect(folio_loan_policy.too_soon_to_renew?).to be false }
+      end
+    end
+
+    describe 'period renew policy where renewal is calculated from the current time' do
+      let(:loan_policy) do
+        { 'loansPolicy' =>
+          { 'fixedDueDateSchedule' => nil,
+            'period' => { 'intervalId' => 'Weeks', 'duration' => 20 } },
+          'renewalsPolicy' =>
+          { 'renewFromId' => 'SYSTEM_DATE',
+            'period' => { 'intervalId' => 'Weeks', 'duration' => 1 },
+            'alternateFixedDueDateSchedule' => nil } }
+      end
+      let(:due_date) { Date.parse('2023-06-30T06:59:59.000+00:00') }
+
+      context 'when renewal would not extend the due date' do
+        it { expect(folio_loan_policy.too_soon_to_renew?).to be true }
+      end
+    end
+
+    describe 'period loan policy where renewal is calculated from current due date' do
+      let(:loan_policy) do
+        { 'loansPolicy' =>
+          { 'fixedDueDateSchedule' => nil,
+            'period' => { 'intervalId' => 'Weeks', 'duration' => 20 } },
+          'renewalsPolicy' =>
+          { 'renewFromId' => 'CURRENT_DUE_DATE',
+            'period' => nil,
+            'alternateFixedDueDateSchedule' => nil } }
+      end
+      let(:due_date) { Date.parse('2024-07-02T06:59:59.000+00:00') }
+
+      context 'when renewal would extend the due date' do
+        it { expect(folio_loan_policy.too_soon_to_renew?).to be false }
+      end
+    end
+  end
+end


### PR DESCRIPTION
This new class suggests some refactoring -- moving loan policy related methods from Folio::Checkout to Folio::LoanPolicy, but I thought it would be better to save that for another PR.