### PR TITLE
Remove unused private methods

### DIFF
--- a/app/models/folio/checkout.rb
+++ b/app/models/folio/checkout.rb
@@ -228,10 +228,5 @@ module Folio
     def location_code
       record.dig('item', 'item', 'effectiveLocation', 'code')
     end
-
-    def item_type
-      nil
-      # fields.dig('item', 'fields', 'itemType', 'key')
-    end
   end
 end

--- a/app/models/folio/request.rb
+++ b/app/models/folio/request.rb
@@ -190,10 +190,5 @@ module Folio
     def location_code
       record.dig('item', 'item', 'effectiveLocation', 'code')
     end
-
-    def item_type
-      # TODO
-      nil
-    end
   end
 end


### PR DESCRIPTION
Private method `item_type` had been used by Symphony implementation to get ILL info. This is no longer needed for the FOLIO implementation.