### PR TITLE
Support retaining our auth cookie during payment

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -27,6 +27,10 @@ module Mylibrary
       manager.default_strategies :shibboleth
     end
 
+    # Set SameSite protection to none so that we can receive POST requests
+    # from Cybersource that include our authentication cookie
+    config.action_dispatch.cookies_same_site_protection = :none
+
     config.library_contact = {
       'ARS' => 'soundarchive@stanford.edu',
       'ART' => 'artlibrary@stanford.edu',

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -48,7 +48,7 @@ Rails.application.configure do
   # config.action_cable.allowed_request_origins = [ 'http://example.com', /http:\/\/example.*/ ]
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
 
   # Include generic and useful information about system operation, but avoid logging too much
   # information to avoid inadvertent exposure of personally identifiable information (PII).

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -62,4 +62,11 @@ Rails.application.configure do
 
   # Annotate rendered view with file names.
   # config.action_view.annotate_rendered_view_with_filenames = true
+
+  # Chrome (including headless) blocks cookies with SameSite=None (which we set
+  # for incoming POSTs from Cybersource) unless the cookie is also Secure;
+  # we can't do that because the test server doesn't use HTTPS. Instead, we
+  # set it to Lax.
+  # See: https://developers.google.com/search/blog/2020/01/get-ready-for-new-samesitenone-secure#chrome-enforcement-starting-in-february-2020
+  config.action_dispatch.cookies_same_site_protection = :lax
 end


### PR DESCRIPTION
- Set the SameSite attribute to None for authentication cookie
- Force SSL when RAILS_ENV=production

This fixes the existing behavior where the user is signed out and redirected to the root after making a payment, because once we go out to Cybersource we lose our authentication cookie.