### PR TITLE
Handle Cybersource payments without redirecting to Symphony

### DIFF
--- a/app/models/cybersource/payment_request.rb
+++ b/app/models/cybersource/payment_request.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+module Cybersource
+  # Request sent to Cybersource to initiate an external checkout
+  class PaymentRequest
+    include Enumerable
+
+    attr_reader :user, :amount, :session_id, :signature, :signed_date_time
+
+    # Set of fields we use to generate the signature and that Cybersource verifies
+    REQUEST_SIGNED_FIELDS = %i[access_key profile_id transaction_uuid signed_date_time
+                               locale transaction_type reference_number amount currency unsigned_field_names
+                               signed_field_names merchant_defined_data1].freeze
+
+    def initialize(user:, amount:, session_id:)
+      @user = user
+      @amount = amount
+      @session_id = session_id
+      @signed_fields = REQUEST_SIGNED_FIELDS
+      @unsigned_fields = []
+      @signed_date_time, @signature = nil
+    end
+
+    # Hash form including all data and signature
+    def to_h
+      signed_data.merge(unsigned_data).merge(signature: @signature)
+    end
+
+    # Support iterating keys and values for rendering as hidden form fields
+    def each(&block)
+      to_h.each(&block)
+    end
+
+    # Generate a security signature for the data and add a timestamp
+    def sign!
+      @signed_date_time = Time.now.utc.strftime('%Y-%m-%dT%H:%M:%SZ')
+      @signature = Cybersource::Security.generate_signature(signed_data)
+
+      self
+    end
+
+    def validate!
+      Cybersource::Security.validate_signature!(@signature, signed_data)
+
+      self
+    end
+
+    def signed?
+      @signature.present?
+    end
+
+    def valid?
+      Cybersource::Security.valid_signature?(@signature, signed_data)
+    end
+
+    private
+
+    # Comma-separated parameter version of signed_fields
+    def signed_field_names
+      @signed_fields.join(',')
+    end
+
+    # Comma-separated parameter version of unsigned_fields
+    def unsigned_field_names
+      @unsigned_fields.join(',')
+    end
+
+    # Hash of signed fields and their values
+    def signed_data
+      @signed_data ||= @signed_fields.index_with { |field| send(field) }
+    end
+
+    # Hash of unsigned fields and their values
+    def unsigned_data
+      @unsigned_data ||= @unsigned_fields.index_with { |field| send(field) }
+    end
+
+    # Each transaction must have a unique ID
+    def transaction_uuid
+      @transaction_uuid ||= SecureRandom.uuid
+    end
+
+    # Used to check if the user has a payment pending by comparing to a cookie
+    def reference_number
+      @session_id
+    end
+
+    # Passed back to us by Cybersource and used to look up the user in the ILS
+    def merchant_defined_data1
+      @user
+    end
+
+    # Matches us with configuration on the Cybersource side; differs for dev/test/prod
+    def access_key
+      Settings.cybersource.access_key
+    end
+
+    # Identifies us as a "merchant" to Cybersource; one value for SUL as a whole
+    def profile_id
+      Settings.cybersource.profile_id
+    end
+
+    def transaction_type
+      'sale'
+    end
+
+    def locale
+      'en'
+    end
+
+    def currency
+      'USD'
+    end
+  end
+end

--- a/app/models/cybersource/payment_response.rb
+++ b/app/models/cybersource/payment_response.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module Cybersource
+  # Response sent back by Cybersource after the external checkout is complete
+  class PaymentResponse
+    class PaymentFailed < StandardError; end
+
+    def initialize(fields)
+      @fields = fields
+      @signed_fields = fields['signed_field_names'].split(',')
+      @unsigned_fields = fields['unsigned_field_names'].split(',')
+    end
+
+    def to_h
+      @fields
+    end
+
+    # If the payment was successful, Cybersource will send us back a decision of 'ACCEPT'
+    def payment_success?
+      @fields['decision'] == 'ACCEPT'
+    end
+
+    # Raise an error if the payment failed or if the signature is invalid
+    def validate!
+      Cybersource::Security.validate_signature!(@fields['signature'], signed_data)
+      raise PaymentFailed unless payment_success?
+
+      self
+    end
+
+    def valid?
+      Cybersource::Security.valid_signature?(@fields['signature'], signed_data)
+    end
+
+    # Hash of signed fields and their values
+    def signed_data
+      @signed_data = @signed_fields.index_with { |field| @fields[field] }
+    end
+
+    def user
+      @fields['req_merchant_defined_data1']
+    end
+
+    def amount
+      @fields['req_amount']
+    end
+
+    def session_id
+      @fields['req_reference_number']
+    end
+  end
+end

--- a/app/services/cybersource/security.rb
+++ b/app/services/cybersource/security.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Cybersource
+  # Methods for encoding and decoding transaction data
+  class Security
+    class InvalidSignature < StandardError; end
+
+    class << self
+      # Cybersource uses a base64 encoded HMAC SHA256 digest to sign the data
+      def generate_signature(data)
+        payload = data.map { |key, value| "#{key}=#{value}" }.join(',')
+        Base64.encode64(OpenSSL::HMAC.digest('sha256', secret_key, payload)).strip
+      end
+
+      # If the signature matches the data, we know it hasn't been tampered with
+      def valid_signature?(signature, data)
+        generate_signature(data) == signature
+      end
+
+      # Raise an error if the signature doesn't match the data
+      def validate_signature!(signature, data)
+        raise InvalidSignature unless valid_signature?(signature, data)
+      end
+
+      private
+
+      def secret_key
+        Settings.cybersource.secret_key
+      end
+    end
+  end
+end

--- a/app/services/folio_client.rb
+++ b/app/services/folio_client.rb
@@ -212,6 +212,11 @@ class FolioClient
     Folio::Patron.new({ 'user' => user })
   end
 
+  # TODO: https://github.com/sul-dlss/mylibrary/issues/889
+  def pay_fines(_user:, _amount:, _session_id:)
+    pass
+  end
+
   private
 
   def check_response(response, title:, context:)

--- a/app/views/fines/_pay_all_button.html.erb
+++ b/app/views/fines/_pay_all_button.html.erb
@@ -1,17 +1,18 @@
 <% fines = patron_or_group.fines %>
-<% if fines.sum(&:owed).positive? %>
+<% amount = fines.sum(&:owed) %>
+<% if amount.positive? %>
   <div>
     <% if patron_or_group.can_pay_fines? %>
       <%= form_tag payments_path, method: :post do %>
         <%= hidden_field_tag :reason, fines.map(&:status).join(',') %>
         <%= hidden_field_tag :billseq, fines.map(&:sequence).values_at(0, -1).join('-') %>
-        <%= hidden_field_tag :amount, format('%.2f', fines.sum(&:owed)) %>
+        <%= hidden_field_tag :amount, format('%.2f', amount) %>
         <%= hidden_field_tag :session_id, SecureRandom.hex %>
         <%= hidden_field_tag :group, patron_or_group.is_a?(Symphony::Group) ? 'G' : '' %>
         <%= hidden_field_tag :user, patron_or_group.barcode %>
         <%= button_tag class: 'btn btn-md btn-info', type: 'submit', data: { 'pay-button' => true } do %>
           <%= sul_icon :'sharp-payment-24px' %>
-          <span>Pay <%= number_to_currency(patron_or_group.fines.sum(&:owed)) %> now</span>
+          <span>Pay <%= number_to_currency(amount) %> now</span>
         <% end %>
       <% end %>
     <% else %>

--- a/app/views/payments/cybersource_form.html.erb
+++ b/app/views/payments/cybersource_form.html.erb
@@ -1,0 +1,15 @@
+<html charset="utf-8">
+  <head>
+    <title>Redirecting to Cybersource...</title>
+  </head>
+  <body>
+    <form id="cybersource_form" action="<%= Settings.cybersource.payment_url %>" method="post">
+      <% @params.each do |name, value| %>
+        <%= hidden_field_tag name, value %>
+      <% end %>
+    </form>
+    <script nonce="<%= content_security_policy_nonce %>">
+      document.getElementById("cybersource_form").submit();
+    </script>
+  </body>
+</html>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -80,6 +80,8 @@ en:
     fine_payment:
       accept_html: <span class="font-weight-bold">Success!</span> $%{amount} paid. A receipt has been sent to the email address associated with your account. Payment may take up to 5 minutes to appear in your payment history.
       cancel_html: <span class="font-weight-bold">Payment canceled.</span> No payment was made &mdash; your payable balance remains unchanged.
+      request_failed_html: <span class="font-weight-bold">Sorry!</span> Something went wrong, possibly due to a connection failure. Please <a href="mailto:sul-privileges@stanford.edu">contact us</a> for help resolving your fines.
+      payment_failed_html: <span class="font-weight-bold">Sorry!</span> Payment failed. Please <a href="mailto:sul-privileges@stanford.edu">contact us</a> for help resolving your fines.
     sessions:
       login_by_library_id:
         alert: Unable to authenticate.

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -56,3 +56,9 @@ purl:
 analytics_debug: true
 
 mailer_host: 'localhost'
+
+cybersource:
+  payment_url: https://secureacceptance.cybersource.com/pay
+  access_key: 'change_me'
+  secret_key: 'change_me'
+  profile_id: 'change_me'

--- a/spec/models/cybersource/payment_request_spec.rb
+++ b/spec/models/cybersource/payment_request_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Cybersource::PaymentRequest do
+  subject(:request_params) do
+    described_class.new(user: '1234567890', amount: '100.00', session_id: '3672f43945ec20cf2966525aeb7691e4').sign!.to_h
+  end
+
+  before do
+    allow(Cybersource::Security).to receive(:secret_key).and_return('very_secret')
+  end
+
+  it 'stores the user barcode as merchant defined data' do
+    expect(request_params[:merchant_defined_data1]).to eq('1234567890')
+  end
+
+  it 'stores the amount of total charges' do
+    expect(request_params[:amount]).to eq('100.00')
+  end
+
+  it 'stores the session id as the transaction reference number' do
+    expect(request_params[:reference_number]).to eq('3672f43945ec20cf2966525aeb7691e4')
+  end
+
+  it 'signs the transaction parameters' do
+    expect(request_params[:signature]).to be_present
+  end
+end

--- a/spec/models/cybersource/payment_response_spec.rb
+++ b/spec/models/cybersource/payment_response_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Cybersource::PaymentResponse do
+  subject(:cybersource_response) { described_class.new(params.permit!.to_h) }
+
+  let(:signature) do
+    Cybersource::Security.generate_signature(
+      {
+        req_merchant_defined_data1: '1234567890',
+        req_amount: '100.00',
+        req_reference_number: '3672f43945ec20cf2966525aeb7691e4'
+      }
+    )
+  end
+  let(:decision) { 'ACCEPT' }
+  let(:params) do
+    ActionController::Parameters.new(req_merchant_defined_data1: '1234567890',
+                                     req_amount: '100.00',
+                                     req_reference_number: '3672f43945ec20cf2966525aeb7691e4',
+                                     signed_field_names: 'req_merchant_defined_data1,req_amount,req_reference_number',
+                                     unsigned_field_names: '',
+                                     signature: signature,
+                                     decision: decision)
+  end
+
+  it 'parses the user barcode from the merchant defined data' do
+    expect(cybersource_response.user).to eq('1234567890')
+  end
+
+  it 'parses the amount of total charges' do
+    expect(cybersource_response.amount).to eq('100.00')
+  end
+
+  it 'parses the session id from the transaction reference number' do
+    expect(cybersource_response.session_id).to eq('3672f43945ec20cf2966525aeb7691e4')
+  end
+
+  it 'validates that the transaction is signed and accepted' do
+    expect { cybersource_response.validate! }.not_to raise_error
+  end
+
+  context 'when the signature is invalid' do
+    let(:signature) { 'badsignature123' }
+
+    it 'raises an error' do
+      expect { cybersource_response.validate! }.to raise_error(Cybersource::Security::InvalidSignature)
+    end
+  end
+
+  context 'when the payment failed' do
+    let(:decision) { 'REJECT' }
+
+    it 'raises an error' do
+      expect { cybersource_response.validate! }.to raise_error(Cybersource::PaymentResponse::PaymentFailed)
+    end
+  end
+end


### PR DESCRIPTION
This PR supersedes (and was based on) #878. It closes #883.

See the changes to the README for some background on the payment process.

Before this PR, the process of sending information to and from Cybersource via POST was done by some PHP scripts that are located on the Symphony VMs. After the transaction with Cybersource, the PHP scripts in turn called a perl script on the same Symphony VM called `transactionPost.pl` which used some of Symphony's locally-available scripts (not web services or APIs) to actually mark the fine as paid.

After this PR, the code that sends users to and from Cybersource has moved into MyLibrary as ruby (it takes essentially the same approach of rendering an interstitial form). After the transaction is completed, MyLibrary calls the `transactionPost.pl` script to mark the fine as paid, in the same way that it would make other calls to Symphony web services/APIs. This seam allows us to separate the checkout process from the ILS, so that #889 is just a matter of implementing `FolioClient#pay_fines`.

I tested this approach and successfully paid the fines (in Symphony) for user GRAD1, who no longer has any fines to pay. @jgreben confirmed that `transactionPost.pl` was successfully called from MyLibrary. If you want to test the process as well, ask me for the settings that correspond to the "local dev" Cybersource profile, which will redirect you to `localhost` after payment is completed.

config PRs for new Cybersource config:
- https://github.com/sul-dlss/shared_configs/pull/2022
- https://github.com/sul-dlss/shared_configs/pull/2023
- https://github.com/sul-dlss/puppet/pull/9737

not sure whether we need configs for mylibrary-dev (going away) or mylibrary-uat (just use prod config?)