### PR TITLE
Set SameSite cookie attribute to 'Lax' in development

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -43,7 +43,7 @@ Metrics/CyclomaticComplexity:
 Metrics/BlockLength:
   Exclude:
     - 'app/views/**/*.json.jbuilder'
-    - 'config/environments/test.rb'
+    - 'config/environments/*.rb'
     - 'config/routes.rb'
     - 'spec/**/*'
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -72,4 +72,11 @@ Rails.application.configure do
 
   # Uncomment if you wish to allow Action Cable access from any origin.
   # config.action_cable.disable_request_forgery_protection = true
+
+  # Chrome (including headless) blocks cookies with SameSite=None (which we set
+  # for incoming POSTs from Cybersource) unless the cookie is also Secure;
+  # we can't do that because the test server doesn't use HTTPS. Instead, we
+  # set it to Lax.
+  # See: https://developers.google.com/search/blog/2020/01/get-ready-for-new-samesitenone-secure#chrome-enforcement-starting-in-february-2020
+  config.action_dispatch.cookies_same_site_protection = :lax
 end


### PR DESCRIPTION
See #887; this just applies the same fix we currently use in test
to the dev server so that authentication, etc. will work in
local dev.
