### PR TITLE
Don't show the login banner if you can't login

### DIFF
--- a/app/views/sessions/index.html.erb
+++ b/app/views/sessions/index.html.erb
@@ -1,6 +1,7 @@
-<h1>Log in to see your checkouts, requests, fines &amp; fees</h1>
 
 <% if @ils_ok %>
+  <h1>Log in to see your checkouts, requests, fines &amp; fees</h1>
+
   <div class="row">
     <div class="page-section col-12 col-sm-6">
       <h2>Stanford students, faculty, staff</h2>


### PR DESCRIPTION
Previously it looked like this:
<img width="855" alt="Screenshot 2023-08-04 at 11 34 48 AM" src="https://github.com/sul-dlss/mylibrary/assets/92044/e5ded092-1596-4e0c-bc8d-03d31390dc51">
