### PR TITLE
Use service points for FOLIO request options

### DIFF
--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -39,7 +39,7 @@ class RequestsController < ApplicationController
     flash[:success] = []
     flash[:error] = []
 
-    handle_pickup_change_request if params['pickup_library'].present?
+    handle_pickup_change_request if params['service_point'].present?
     handle_not_needed_after_request if params['not_needed_after'].present? &&
                                        params['not_needed_after'] != params['current_fill_by_date']
 
@@ -78,7 +78,9 @@ class RequestsController < ApplicationController
   def handle_pickup_change_request
     change_pickup_response = ils_client.change_pickup_library(*change_pickup_params)
     case change_pickup_response.status
-    when 200
+    # The FOLIO API returns 204
+    # TODO: after FOLIO launch remove the 200 case which was the Symphony response
+    when 200, 204
       flash[:success].push(t('mylibrary.request.update_pickup.success_html', title: params['title']))
     else
       Rails.logger.error(change_pickup_response.body)
@@ -102,7 +104,12 @@ class RequestsController < ApplicationController
   end
 
   def change_pickup_params
-    params.require(%I[resource id pickup_library])
+    # TODO: after Folio launch remove conditional wrapper and delete the else (Symphony) part
+    if ils_client.is_a?(FolioClient)
+      params.require(%I[id service_point])
+    else
+      params.require(%I[resource id service_point])
+    end
   end
 
   def not_needed_after_params

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -65,12 +65,13 @@ module ApplicationHelper
     Mylibrary::Application.config.library_map[code] || code
   end
 
-  # FOLIO distinguishes between service points and libraries (that can share codes)
-  #   so we need a separate method for correct code to name lookup
+  # TODO: After FOLIO launch remove the conditional wrapper and rename to reflect service point terminology
   def pickup_location_name(code)
-    Mylibrary::Application.config.library_map[code] ||
-      Folio::ServicePoint.find_by(id: code)&.discoveryDisplayName ||
-      code
+    if Settings.ils.client == 'FolioClient'
+      Folio::ServicePoint.name_by_code(code) || code
+    else
+      Mylibrary::Application.config.library_map[code] || code
+    end
   end
 
   def library_email(code)

--- a/app/helpers/requests_helper.rb
+++ b/app/helpers/requests_helper.rb
@@ -5,12 +5,29 @@ module RequestsHelper
   ##
   # Generates the options needed to change a request's location
   def request_location_options(request)
-    options_for_select(
-      LibraryLocation.new(request.home_location)
-        .additional_pickup_libraries(request.pickup_library).index_by do |code|
-          Mylibrary::Application.config.library_map[code]
-        end
-    )
+    # TODO: after FOLIO launch remove this conditional wrapper
+    if request.is_a?(Folio::Request)
+      return options_for_select(
+        service_points(request),
+        # the second param here pre-selects the current service point in the dropdown
+        selected: request.service_point_id
+      )
+    end
+
+    options_for_select(LibraryLocation.new(request.home_location)
+                             .additional_pickup_libraries(request.pickup_library).index_by do |code|
+                         Mylibrary::Application.config.library_map[code]
+                       end)
+  end
+
+  # Generates a list of service point options for a request.
+  #
+  # @param request [Request] The request object
+  # @return [Array<Array<String, String>>] Array of service points in [label, value] format for options_for_select
+  def service_points(request)
+    return restricted_service_point_options(request) if request.restricted_pickup_service_points.present?
+
+    service_point_options(request)
   end
 
   def check_in_cdl_link(request)
@@ -45,5 +62,29 @@ module RequestsHelper
     }
 
     "#{Settings.embed.url}/iframe?#{params.to_query}"
+  end
+
+  # Returns an array of service point options in the format for options_for_select: [[label1, value1], [label2, value2]]
+  #
+  # @param request [Request] The request object
+  # @return [Array<Array<String, String>>] An array of service point options in [label, value] format
+  def restricted_service_point_options(request)
+    request.restricted_pickup_service_points.map do |item|
+      [item['discoveryDisplayName'], item['id']]
+    end
+  end
+
+  # Returns an array of service point options in the format for options_for_select: [[label1, value1], [label2, value2]]
+  #
+  # @param request [Request] The request object
+  # @return [Array<Array<String, String>>] An array of service point options in [label, value] format
+  def service_point_options(request)
+    # start with the full list of defaults
+    default_service_points = Folio::ServicePoint.default_service_points
+    # Add the request's origin service point to the list
+    default_service_points << Folio::ServicePoint.find_by_id(request.service_point_id) # rubocop:disable Rails/DynamicFindBy
+    # Remove duplicates and nils in case origin was already in the default list or wasn't a pickup_location=true point
+    # Map the service points to the [label, value] format for options_for_select
+    default_service_points.compact.uniq(&:id).map { |item| [item.name, item.id] }
   end
 end

--- a/app/models/borrow_direct_reshare_requests.rb
+++ b/app/models/borrow_direct_reshare_requests.rb
@@ -88,7 +88,7 @@ class BorrowDirectReshareRequests
       @request_json.fetch('patronIdentifier', nil)
     end
 
-    def pickup_library; end
+    def service_point; end
 
     def ready_for_pickup?
       false

--- a/app/models/folio/request.rb
+++ b/app/models/folio/request.rb
@@ -91,10 +91,20 @@ module Folio
       "#{queue_position - cdl_queue_length} of #{queue_length - cdl_queue_length}"
     end
 
+    # TODO: After FOLIO launch change this method name to reflect FOLIO service point terminology
+    # and possibly simplify / directly use the service point id rather than routing through the code
     def pickup_library
       return 'CDL' if cdl?
 
       record.dig('pickupLocation', 'code')
+    end
+
+    def service_point_id
+      record['pickupLocationId']
+    end
+
+    def restricted_pickup_service_points
+      record.dig('item', 'item', 'effectiveLocation', 'details', 'pageServicePoints')
     end
 
     # this is only used in JSON responses; maybe we can remove it?

--- a/app/models/folio/service_point.rb
+++ b/app/models/folio/service_point.rb
@@ -2,15 +2,45 @@
 
 module Folio
   class ServicePoint
-    MAPPING_FILE = 'config/folio/service-points.json'
+    attr_reader :id, :code, :name, :pickup_location, :is_default_pickup, :is_default_for_campus
+
+    # rubocop:disable Rubocop/Metrics/ParameterLists
+    def initialize(id:, code:, name:, pickup_location:, is_default_pickup:, is_default_for_campus:)
+      @id = id
+      @code = code
+      @name = name
+      @pickup_location = pickup_location
+      @is_default_pickup = is_default_pickup
+      @is_default_for_campus = is_default_for_campus
+    end
+    # rubocop:enable Rubocop/Metrics/ParameterLists
 
     class << self
-      include Folio::CodeMapper
+      def all
+        @all ||= FolioClient.new.service_points.map { |json| from_dynamic(json) }
+      end
+
+      def default_service_points
+        all.select { |item| item.is_default_pickup == true }
+      end
+
+      def name_by_code(code)
+        all.find { |item| item.code == code }&.name
+      end
+
+      def find_by_id(id)
+        all.find { |item| item.id == id }
+      end
 
       private
 
-      def mapping_file
-        MAPPING_FILE
+      def from_dynamic(json)
+        new(id: json.fetch('id'),
+            code: json.fetch('code'),
+            name: json.fetch('discoveryDisplayName'),
+            pickup_location: json.fetch('pickupLocation', false),
+            is_default_pickup: json.dig('details', 'isDefaultPickup'),
+            is_default_for_campus: json.dig('details', 'isDefaultForCampus'))
       end
     end
   end

--- a/app/services/folio_client.rb
+++ b/app/services/folio_client.rb
@@ -58,6 +58,8 @@ class FolioClient
     folio_graphql_client.patron_info(patron_key)
   end
 
+  delegate :service_points, to: :folio_graphql_client
+
   # FOLIO API call
   def patron_account(patron_key, item_details: {})
     get_json("/patron/account/#{CGI.escape(patron_key)}", params: {
@@ -135,19 +137,21 @@ class FolioClient
     response
   end
 
-  # Change hold request date
-  # @example client.change_pickup_location(hold_id: '4a64eccd-3e44-4bb0-a0f7-9b4c487abf61',
+  # TODO: after FOLIO launch rename this method to reflect service point terminology (maybe change_pickup_service_point)
+  #
+  # Change hold request service point
+  # @example client.change_pickup_library(hold_id: '4a64eccd-3e44-4bb0-a0f7-9b4c487abf61',
   #                                        pickup_location_id: 'bd5fd8d9-72f3-4532-b68c-4db88063d16b')
-  # @param [String] hold_id the UUID of the FOLIO hold
-  # @param [String] pickup_location_id the uuid of the new location
-  def change_pickup_location(hold_id:, pickup_location_id:)
-    request_data = get_json("/circulation/requests/#{hold_id}")
-    request_data['pickupServicePointId'] = 'bd5fd8d9-72f3-4532-b68c-4db88063d16b'
-    response = put("/circulation/requests/#{hold_id}", json: request_data)
-
+  # @param [String] id the UUID of the FOLIO hold
+  # @param [String] service_point the UUID of the new service point
+  def change_pickup_library(id, service_point)
+    request_data = get_json("/circulation/requests/#{id}")
+    request_data['pickupServicePointId'] = service_point
+    response = put("/circulation/requests/#{id}", json: request_data)
     check_response(response, title: 'Change pickup location',
-                             context: { hold_id: hold_id,
-                                        pickup_location_id: pickup_location_id })
+                             context: { id: id,
+                                        service_point: service_point })
+    response
   end
 
   # @example client.change_pickup_expiration(hold_id: '4a64eccd-3e44-4bb0-a0f7-9b4c487abf61',

--- a/app/services/folio_graphql_client.rb
+++ b/app/services/folio_graphql_client.rb
@@ -45,6 +45,26 @@ class FolioGraphqlClient
     parse(post(path, **kwargs))
   end
 
+  def service_points
+    data = post_json('/', json: {
+      query: "query ServicePoints {
+        servicePoints {
+          discoveryDisplayName
+          id
+          code
+          pickupLocation
+          details {
+            isDefaultForCampus
+            isDefaultPickup
+          }
+        }
+      }"
+    })
+    raise data['errors'].pluck('message').join("\n") if data.key?('errors')
+
+    data.dig('data', 'servicePoints')
+  end
+
   def patron_info(patron_uuid)
     data = post_json('/', json: {
       query: "query Query($patronId: UUID!) {
@@ -129,6 +149,14 @@ class FolioGraphqlClient
                   code
                   library {
                     code
+                  }
+                  details {
+                    pageServicePoints {
+                      code
+                      id
+                      discoveryDisplayName
+                      pickupLocation
+                    }
                   }
                 }
               }

--- a/app/services/symphony_client.rb
+++ b/app/services/symphony_client.rb
@@ -168,7 +168,7 @@ class SymphonyClient
     })
   end
 
-  def change_pickup_library(resource, item_key, pickup_library)
+  def change_pickup_library(resource, item_key, service_point)
     authenticated_request('/circulation/holdRecord/changePickupLibrary', method: :post, json: {
       holdRecord: {
         resource: resource,
@@ -176,7 +176,7 @@ class SymphonyClient
       },
       pickupLibrary: {
         resource: '/policy/library',
-        key: pickup_library
+        key: service_point
       }
     })
   end

--- a/app/views/requests/edit.html.erb
+++ b/app/views/requests/edit.html.erb
@@ -10,8 +10,8 @@
     <%= hidden_field_tag :group, params[:group] if params[:group] %>
     <%= hidden_field_tag :current_fill_by_date, @request&.fill_by_date&.strftime('%Y-%m-%d') %>
     <div class="form-group">
-      <%= label_tag :pickup_library, 'Pickup library' %>
-      <%= select_tag :pickup_library, request_location_options(@request), include_blank: pickup_location_name(@request.pickup_library), class: 'form-control' %>
+      <%= label_tag :service_point, 'Pickup point' %>
+      <%= select_tag :service_point, request_location_options(@request), class: 'form-control' %>
     </div>
     <% if @request.fill_by_date %>
       <div class="form-group">

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -6,3 +6,8 @@ symws:
     password: 'some_password'
 symphony:
   host: example.com
+
+folio:
+  url: 'https://user:password@okapi.stanford.edu'
+folio_graphql:
+  url: 'http://user:password@localhost:4000'

--- a/spec/controllers/requests_controller_spec.rb
+++ b/spec/controllers/requests_controller_spec.rb
@@ -100,11 +100,11 @@ RSpec.describe RequestsController do
         end
       end
 
-      context 'when pickup_library param is sent' do
+      context 'when service_point param is sent' do
         let(:mock_client) { instance_double(SymphonyClient, change_pickup_library: api_response, ping: true) }
 
         it 'updates the pickup library and sets the flash message' do
-          patch :update, params: { resource: 'abc', id: '123', pickup_library: 'Other library' }
+          patch :update, params: { resource: 'abc', id: '123', service_point: 'Other library' }
 
           expect(flash[:success].first).to match(/Success!.*pickup location was updated/)
         end
@@ -132,7 +132,7 @@ RSpec.describe RequestsController do
         let(:mock_client) { instance_double(SymphonyClient, change_pickup_library: api_response, ping: true) }
 
         it 'renews the item and redirects to checkouts_path' do
-          patch :update, params: { resource: 'abc', id: '123', pickup_library: 'Other library', group: true }
+          patch :update, params: { resource: 'abc', id: '123', service_point: 'Other library', group: true }
 
           expect(response).to redirect_to requests_path(group: true)
         end

--- a/spec/factories/service_points.rb
+++ b/spec/factories/service_points.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  mock_data = [
+    { 'discoveryDisplayName' => 'Classics Library',
+      'id' => '8bb5d494-263f-42f0-9a9f-70451530d8a3',
+      'code' => 'CLASSICS',
+      'pickupLocation' => false,
+      'details' => nil },
+    { 'discoveryDisplayName' => 'Archive of Recorded Sound',
+      'id' => 'faa81922-3da8-4086-a7fa-977d7d3e7977',
+      'code' => 'ARS',
+      'pickupLocation' => true,
+      'details' => nil },
+    { 'discoveryDisplayName' => 'Engineering Library (Terman)',
+      'id' => 'd0db91bf-90e7-4036-8e91-721001cf52fc',
+      'code' => 'ENG',
+      'pickupLocation' => true,
+      'details' => { 'isDefaultForCampus' => nil, 'isDefaultPickup' => true } },
+    { 'discoveryDisplayName' => 'Green Library',
+      'id' => 'a5dbb3dc-84f8-4eb3-8bfe-c61f74a9e92d',
+      'code' => 'GREEN-LOAN',
+      'pickupLocation' => true,
+      'details' => { 'isDefaultForCampus' => 'SUL', 'isDefaultPickup' => true } }
+  ]
+  factory :service_points, class: 'Array' do
+    skip_create
+
+    initialize_with do
+      mock_data.map do |entry|
+        Folio::ServicePoint.new(id: entry.fetch('id'),
+                                code: entry.fetch('code'),
+                                name: entry.fetch('discoveryDisplayName'),
+                                pickup_location: entry.fetch('pickupLocation', false),
+                                is_default_pickup: entry.dig('details', 'isDefaultPickup'),
+                                is_default_for_campus: entry.dig('details', 'isDefaultForCampus'))
+      end
+    end
+  end
+  factory :default_service_points, class: 'Array' do
+    skip_create
+
+    initialize_with do
+      defaults = mock_data.select { |entry| entry.dig('details', 'isDefaultPickup') == true }
+      defaults.map do |entry|
+        Folio::ServicePoint.new(id: entry.fetch('id'),
+                                code: entry.fetch('code'),
+                                name: entry.fetch('discoveryDisplayName'),
+                                pickup_location: entry.fetch('pickupLocation', false),
+                                is_default_pickup: entry.dig('details', 'isDefaultPickup'),
+                                is_default_for_campus: entry.dig('details', 'isDefaultForCampus'))
+      end
+    end
+  end
+end

--- a/spec/features/requests_spec.rb
+++ b/spec/features/requests_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe 'Request Page' do
 
   it 'is editable' do
     visit edit_request_path('1675117')
-    select('East Asia Library', from: 'pickup_library')
+    select('East Asia Library', from: 'service_point')
     fill_in('not_needed_after', with: '1999/01/01')
     click_button 'Change'
     expect(page).to have_css 'div.alert-success', text: 'Success!', count: 2

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -103,11 +103,12 @@ RSpec.describe ApplicationHelper do
     end
 
     it 'falls back on the code' do
+      allow(Folio::ServicePoint).to receive(:name_by_code).and_return(nil)
       expect(helper.pickup_location_name('NOSUCHLIBRARY')).to eq 'NOSUCHLIBRARY'
     end
 
     it 'translates a FOLIO service point code to a human-readable name' do
-      expect(helper.pickup_location_name('cd2')).to eq 'Circulation Desk -- Back Entrance'
+      expect(helper.pickup_location_name('EAST-ASIA')).to eq 'East Asia Library'
     end
   end
 

--- a/spec/helpers/requests_helper_spec.rb
+++ b/spec/helpers/requests_helper_spec.rb
@@ -3,17 +3,125 @@
 require 'rails_helper'
 
 RSpec.describe RequestsHelper do
-  describe '#request_location_options' do
-    let(:request) { instance_double(Symphony::Request, pickup_library: 'GREEN', home_location: 'STACKS') }
+  context 'with a Symphony request' do
+    describe '#request_location_options' do
+      let(:request) { instance_double(Symphony::Request, pickup_library: 'GREEN', home_location: 'STACKS') }
 
-    it 'creates options for a requests location to be changed' do
-      options = helper.request_location_options(request)
-      expect(options).to have_css 'option', count: 11
+      it 'creates options for a requests location to be changed' do
+        options = helper.request_location_options(request)
+        expect(options).to have_css 'option', count: 11
+      end
+
+      it 'creates options with value and text' do
+        options = helper.request_location_options(request)
+        expect(options).to have_css 'option[value="HOPKINS"]', text: 'Marine Biology Library (Miller)'
+      end
+    end
+  end
+
+  context 'with a FOLIO request' do
+    let(:default_service_points) do
+      build(:default_service_points)
     end
 
-    it 'creates options with value and text' do
-      options = helper.request_location_options(request)
-      expect(options).to have_css 'option[value="HOPKINS"]', text: 'Marine Biology Library (Miller)'
+    before do
+      allow(Folio::ServicePoint).to receive_messages(
+        default_service_points: default_service_points
+      )
+    end
+
+    describe '#request_location_options' do
+      context 'with a restricted pickup service point' do
+        let(:request) do
+          instance_double(Folio::Request, pickup_library: 'ART',
+                                          service_point_id: '77cd12ac-2de8-4d13-99a0-f6b3b4f4bdca')
+        end
+
+        before do
+          allow(request).to receive(:restricted_pickup_service_points).and_return([{
+            'code' => 'ART',
+            'id' => '77cd12ac-2de8-4d13-99a0-f6b3b4f4bdca',
+            'discoveryDisplayName' => 'Art & Architecture (Bowes)',
+            'pickupLocation' => true
+          }])
+          allow(request).to receive(:is_a?).with(Folio::Request).and_return(true)
+        end
+
+        it 'only allows the restricted service point as an option' do
+          options = helper.request_location_options(request)
+          expect(options).to have_css 'option', count: 1
+        end
+
+        it 'creates option with correct value and text' do
+          options = helper.request_location_options(request)
+          expect(options).to have_css 'option[value="77cd12ac-2de8-4d13-99a0-f6b3b4f4bdca"]',
+                                      text: 'Art & Architecture (Bowes)'
+        end
+      end
+
+      context 'with a non-restricted pickup service point' do
+        let(:request) do
+          instance_double(Folio::Request, pickup_library: 'GREEN-LOAN',
+                                          service_point_id: 'a5dbb3dc-84f8-4eb3-8bfe-c61f74a9e92d')
+        end
+
+        before do
+          allow(Folio::ServicePoint).to receive_messages(
+            find_by_id: instance_double(Folio::ServicePoint,
+                                        code: 'GREEN-LOAN',
+                                        id: 'a5dbb3dc-84f8-4eb3-8bfe-c61f74a9e92d',
+                                        is_default_for_campus: 'SUL',
+                                        is_default_pickup: true,
+                                        name: 'Green Library',
+                                        pickup_location: true)
+          )
+          allow(request).to receive(:restricted_pickup_service_points).and_return(nil)
+          allow(request).to receive(:is_a?).with(Folio::Request).and_return(true)
+        end
+
+        it 'puts all the defaults into the options list' do
+          options = helper.request_location_options(request)
+          expect(options).to have_css 'option', count: 2
+        end
+
+        it 'pre-selects the origin service point of the request' do
+          options = helper.request_location_options(request)
+          expect(options).to have_selector("option[selected='selected'][value='a5dbb3dc-84f8-4eb3-8bfe-c61f74a9e92d']",
+                                           text: 'Green Library')
+        end
+      end
+
+      context 'with a non-default origin pickup service point' do
+        let(:request) do
+          instance_double(Folio::Request, pickup_library: 'ARS',
+                                          service_point_id: 'faa81922-3da8-4086-a7fa-977d7d3e7977')
+        end
+
+        before do
+          allow(Folio::ServicePoint).to receive_messages(
+            find_by_id: instance_double(Folio::ServicePoint,
+                                        code: 'ARS',
+                                        id: 'faa81922-3da8-4086-a7fa-977d7d3e7977',
+                                        is_default_for_campus: nil,
+                                        is_default_pickup: false,
+                                        name: 'Archive of Recorded Sound',
+                                        pickup_location: true)
+          )
+          allow(request).to receive(:restricted_pickup_service_points).and_return(nil)
+          allow(request).to receive(:is_a?).with(Folio::Request).and_return(true)
+        end
+
+        it 'adds the origin service point to the default options list if it is a pickup location' do
+          options = helper.request_location_options(request)
+          expect(options).to have_css 'option', count: 3
+        end
+
+        it 'pre-selects the origin service point of the request' do
+          options = helper.request_location_options(request)
+          expect(options).to have_selector("option[selected='selected'][value='faa81922-3da8-4086-a7fa-977d7d3e7977']",
+                                           text: 'Archive of Recorded Sound')
+        end
+      end
     end
   end
 end

--- a/spec/models/borrow_direct_reshare_requests_spec.rb
+++ b/spec/models/borrow_direct_reshare_requests_spec.rb
@@ -118,8 +118,8 @@ RSpec.describe BorrowDirectReshareRequests do
       expect(request.patron_id).to eq '12345678'
     end
 
-    it 'always returns nil for pickup_library' do
-      expect(request.pickup_library).to be_nil
+    it 'always returns nil for service_point' do
+      expect(request.service_point).to be_nil
     end
 
     it { expect(request).not_to be_ready_for_pickup }

--- a/spec/models/folio/service_point_spec.rb
+++ b/spec/models/folio/service_point_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Folio::ServicePoint do
+  let(:service_points) do
+    build(:service_points)
+  end
+
+  before do
+    allow(described_class).to receive_messages(
+      all: service_points
+    )
+  end
+
+  describe '.all' do
+    it 'returns an array of service points' do
+      expect(described_class.all.first).to be_a described_class
+    end
+
+    it 'returns all the service points' do
+      expect(described_class.all.size).to eq(4)
+    end
+  end
+
+  describe '.default_service_points' do
+    it 'returns only the default service points' do
+      expect(described_class.default_service_points.size).to eq(2)
+    end
+  end
+
+  describe '.name_by_code' do
+    it 'returns the name of the service point' do
+      expect(described_class.name_by_code('GREEN-LOAN')).to eq 'Green Library'
+    end
+
+    it 'returns nil for an unknown code' do
+      expect(described_class.name_by_code('FAKELIB')).to be_nil
+    end
+  end
+
+  describe '.find_by_id' do
+    it 'returns the service point' do
+      expect(described_class.find_by_id('a5dbb3dc-84f8-4eb3-8bfe-c61f74a9e92d')).to be_a described_class # rubocop:disable Rails/DynamicFindBy
+    end
+
+    it 'returns nil for an unknown id' do
+      expect(described_class.find_by_id('fake-123-345')).to be_nil # rubocop:disable Rails/DynamicFindBy
+    end
+  end
+end

--- a/spec/views/requests/_request.html.erb_spec.rb
+++ b/spec/views/requests/_request.html.erb_spec.rb
@@ -34,6 +34,8 @@ RSpec.describe 'requests/_request' do
         allow(view).to receive(:patron).and_return(patron)
       end
 
+      allow(Mylibrary::Application.config.library_map).to receive(:[]).with('SAL3').and_return('SAL3 Library')
+      allow(Mylibrary::Application.config.library_map).to receive(:[]).with('XYZ').and_return('XYZ Library')
       render partial: 'requests/request', locals: { request: mock_request }
     end
 
@@ -78,13 +80,14 @@ RSpec.describe 'requests/_request' do
       )
     end
 
-    let(:patron) { instance_double(Folio::Patron, can_modify_requests?: false, group: group_instance) }
+    let(:patron) { instance_double(Folio::Patron, can_modify_requests?: true, group: group_instance) }
     let(:group_instance) { instance_double(Folio::Group, member_name: 'Piper Proxy') }
 
     before do
       without_partial_double_verification do
         allow(view).to receive_messages(params: { group: true }, patron: patron) # Set params[:group] to true
       end
+      allow(Folio::ServicePoint).to receive(:name_by_code).with('XYZ').and_return('XYZ Library')
       render partial: 'requests/request', locals: { request: mock_request, group: true }
     end
 


### PR DESCRIPTION
The service point model code started based on the same model from `sul-requests`

Closes #875 