### PR TITLE
Remove oci8 gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -64,10 +64,6 @@ group :production do
   gem 'newrelic_rpm'
 end
 
-group :symphony do
-  gem 'ruby-oci8'
-end
-
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem 'capybara'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -357,7 +357,6 @@ GEM
       rubocop (~> 1.33)
       rubocop-capybara (~> 2.17)
       rubocop-factory_bot (~> 2.22)
-    ruby-oci8 (2.2.12)
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
@@ -460,7 +459,6 @@ DEPENDENCIES
   rubocop-performance
   rubocop-rails
   rubocop-rspec
-  ruby-oci8
   selenium-webdriver
   simplecov
   sinatra

--- a/config/initializers/okcomputer.rb
+++ b/config/initializers/okcomputer.rb
@@ -12,15 +12,5 @@ if Settings.ils.client == 'SymphonyClient' && !Settings.folio_migration
     end
   end
 
-  # OKComputer check that checks if we have a connection to the symphony oracle db
-  class SymphonyDbClientCheck < OkComputer::Check
-    def check
-      ping = SymphonyDbClient.new.ping
-
-      mark_failure unless ping
-    end
-  end
-
   OkComputer::Registry.register 'symphony_web_services', SymphonyClientCheck.new
-  OkComputer::Registry.register 'symphony_db_client', SymphonyDbClientCheck.new
 end


### PR DESCRIPTION
the `SymphonyDbClient` implementation appears defensively coded in case the gem isn't available, so it can wait until we clean up all the Symphony stuff 🤷‍♂️ 

Part of #913