### PR TITLE
Update global alert style

### DIFF
--- a/app/assets/stylesheets/modules/global-alert.scss
+++ b/app/assets/stylesheets/modules/global-alert.scss
@@ -1,7 +1,16 @@
- $global-alert-color: rgb(204, 0, 0);
+$global-alert-color: rgb(204, 0, 0);
+$su-bg-digital-green: rgb(0 133 102);
 
 .global-alert {
-  border: 1px solid $global-alert-color;
   margin: 10px auto;
-  padding: 10px;
+  padding: 15px;
+
+  color: white;
+  background: $su-bg-digital-green;
+  border-radius: 8px;
+  font-size: 1.215em;
+
+  p:last-child {
+    margin-bottom: 0;
+  }
 }

--- a/app/assets/stylesheets/modules/global-alert.scss
+++ b/app/assets/stylesheets/modules/global-alert.scss
@@ -1,5 +1,5 @@
 $global-alert-color: rgb(204, 0, 0);
-$su-bg-digital-green: rgb(0 133 102);
+$su-bg-digital-green: rgb(0, 155, 118);
 
 .global-alert {
   margin: 10px auto;


### PR DESCRIPTION
**Before**: See #943
**After**:
<img width="1135" src="https://github.com/sul-dlss/mylibrary/assets/2343316/4a4dcd6a-ba41-41bb-b9a3-27135bf6c1de" alt="Screenshot of alert banner, now emerald green.">

**Changes:** Borrows the emerald green banner color from SUL (to distinguish alerts from the Stanford cardinal).
<img width="855" src="https://github.com/sul-dlss/mylibrary/assets/2343316/11b0676d-5b6f-4253-805d-cf71ee790f5b" alt="Screenshot of SUL website, showing emerald green alert banner.">

Feedback welcome. Happy to make additional changes (e.g., messaging changes in [global_alerts](https://github.com/sul-dlss/global_alerts)). Wasn't sure how much of a re-design is desired here, but this at least makes the alert a bit more noticeable. Thanks!