### PR TITLE
Check item status to determine if it is lost

### DIFF
--- a/app/models/folio/checkout.rb
+++ b/app/models/folio/checkout.rb
@@ -15,6 +15,7 @@ module Folio
              private: true
 
     SHORT_TERM_LOAN_PERIODS = %w[Hours Minutes].freeze
+    FOLIO_LOST_STATUSES = ['Aged to lost', 'Declared lost'].freeze
 
     def initialize(record)
       @record = record
@@ -187,7 +188,7 @@ module Folio
     # rubocop:enable Metrics/MethodLength
 
     def lost?
-      record.dig('details', 'declaredLostDate')
+      FOLIO_LOST_STATUSES.include?(record.dig('item', 'item', 'status', 'name'))
     end
 
     def barcode

--- a/spec/models/folio/checkout_spec.rb
+++ b/spec/models/folio/checkout_spec.rb
@@ -135,4 +135,25 @@ RSpec.describe Folio::Checkout do
       it { expect(checkout).not_to be_from_ill }
     end
   end
+
+  describe 'lost?' do
+    let(:record) do
+      { 'id' => 'dbc35cdf-0fbb-5fbe-8988-b4fa628365c7',
+        'item' =>
+          { 'item' =>
+            { 'status' => { 'name' => status } } } }
+    end
+
+    context 'when the checked out item has a lost status' do
+      let(:status) { 'Aged to lost' }
+
+      it { expect(checkout.lost?).to be true }
+    end
+
+    context 'when the checked out item does not have a lost status' do
+      let(:status) { 'Checked out' }
+
+      it { expect(checkout.lost?).to be false }
+    end
+  end
 end


### PR DESCRIPTION
Fixes many of the `FolioClient::IlsError: Renew request` errors: https://app.honeybadger.io/projects/62116/faults/99827607
Partially addresses #930 