### PR TITLE
Update PIN alerts

### DIFF
--- a/app/assets/stylesheets/modules/global-alert.scss
+++ b/app/assets/stylesheets/modules/global-alert.scss
@@ -1,7 +1,13 @@
- $global-alert-color: rgb(204, 0, 0);
-
 .global-alert {
-  border: 1px solid $global-alert-color;
-  margin: 10px auto;
-  padding: 10px;
+  border: 1px solid $su-digital-red-dark;
+  margin-bottom: 10px;
+  padding: 5px 10px 5px 10px;
+  border-radius: 0.25rem;
+  color: $su-digital-red-dark;
+  p:last-child { margin-bottom: 0; }
+}
+
+.local-alert {
+  @extend .global-alert;
+  width: fit-content;
 }

--- a/app/assets/stylesheets/sul-variables.scss
+++ b/app/assets/stylesheets/sul-variables.scss
@@ -18,6 +18,17 @@ $very-pale-orange: #ffe9c5;
 $very-pale-red: #ffe5ea;
 $white: #fff;
 
+//Stanford University Web Interactive Colors
+$su-digital-red: #b1040e;
+$su-digital-red-light: #e50808;
+$su-digital-red-dark: #820000;
+$su-digital-blue: #006cb8;
+$su-digital-blue-light: #6fc3ff;
+$su-digital-blue-dark: #00548f;
+$su-digital-green: #008566;
+$su-digital-green-light: #1aecba;
+$su-digital-green-dark: #006f54;
+
 //Variables
 $sul-bg-color: $beige-5-percent;
 $sul-btn-default-color: $cloud;

--- a/app/views/reset_pins/index.html.erb
+++ b/app/views/reset_pins/index.html.erb
@@ -1,4 +1,12 @@
-<h1>Request/Reset PIN</h1>
+<h1>Reset/Request PIN</h1>
+<div class="local-alert">
+  <p>
+    <strong>Stanford Libraries upgraded its system on August 27.</strong>
+    <br>
+    Proxy, fee, or courtesy account holders with a login PIN must request a new PIN.
+    Enter your Library ID below and submit the request.
+  </p>
+</div>
 <%= form_tag reset_pin_url, method: :post do %>
   <div class="form-group">
     <%= label_tag :library_id, 'Library ID' %>

--- a/app/views/sessions/index.html.erb
+++ b/app/views/sessions/index.html.erb
@@ -10,6 +10,15 @@
 
     <div class="page-section col-12 col-sm-6">
       <h2><%= proxy_login_header %></h2>
+      <div class="local-alert">
+        <p>
+          <strong>Stanford Libraries upgraded its system on August 27.</strong>
+          <br>
+          Account holders with a login PIN must request a new PIN.
+          <br>
+          Select "Request a PIN" below.
+        </p>
+      </div>
       <%= link_to 'Log in with PIN', login_url, class: 'btn btn-secondary' %>
       <%= link_to 'Request a PIN', reset_pin_path, class: 'btn btn-link' %>
     </div>


### PR DESCRIPTION
- Small updates to the global-alert style
- Extends global-alert to a "local-alert" style
- Local PIN alerts added inline to `request_pins` and `sessions` views. (To be deleted when the PIN alert is no longer applicable.)
- Adds [SU Web Interactive Colors](https://identity.stanford.edu/design-elements/color/web/) (WCAG AA compliant)
- Swaps the "Request/Reset" order in the `request_pins` heading for consistency
- The global PIN alert should be deleted (see [this global_alerts PR](https://github.com/sul-dlss/global_alerts/pull/60))

Issue: #943
Tested: localhost and rake