### PR TITLE
Reduce size of bulk renewal flash message to avoid CookieOverflow

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -44,8 +44,8 @@ en:
       deny_access: An unexpected error has occurred
     renew_all_items:
       success_html:
-        one: <span class="font-weight-bold">Success!</span> 1 item was renewed. %{items}
-        other: <span class="font-weight-bold">Success!</span> %{count} items were renewed. %{items}
+        one: <span class="font-weight-bold">Success!</span> 1 item was renewed.
+        other: <span class="font-weight-bold">Success!</span> %{count} items were renewed.
       error_html:
         one: <span class="font-weight-bold">Sorry!</span> 1 item was not renewed, possibly due to a connection failure. Try again or contact us for help. %{items}
         other: <span class="font-weight-bold">Sorry!</span> %{count} items were not renewed, possibly due to a connection failure. Try again or contact us for help. %{items}

--- a/spec/controllers/renewals_controller_spec.rb
+++ b/spec/controllers/renewals_controller_spec.rb
@@ -100,7 +100,9 @@ RSpec.describe RenewalsController do
       [
         instance_double(Folio::Checkout, key: '1', renewable?: true, item_key: '123', title: 'ABC',
                                          resource: 'item'),
-        instance_double(Folio::Checkout, key: '2', renewable?: true, item_key: '456', title: 'XYZ',
+        instance_double(Folio::Checkout, key: '2', renewable?: true, item_key: '456',
+                                         title: 'Principles of optics : electromagnetic theory of ' \
+                                                'propagation, interference and diffraction of light',
                                          resource: 'item'),
         instance_double(Folio::Checkout, key: '3', renewable?: false, item_key: '789', title: 'Not',
                                          resource: 'item')
@@ -123,8 +125,8 @@ RSpec.describe RenewalsController do
         expect(flash[:success]).to include('Success!')
       end
 
-      it 'includes the titles of successful renewals' do
-        expect(Capybara.string(flash[:success])).to have_css('li', text: 'ABC')
+      it 'includes the number of renewed items' do
+        expect(flash[:success]).to include('1 item was renewed')
       end
     end
 
@@ -135,8 +137,9 @@ RSpec.describe RenewalsController do
         expect(flash[:error]).to include('Sorry!')
       end
 
-      it 'includes the titles of errored renewals' do
-        expect(Capybara.string(flash[:error])).to have_css('li', text: 'XYZ')
+      it 'includes the truncated titles of errored renewals' do
+        expect(Capybara.string(flash[:error])).to have_css('li',
+                                                           text: 'Principles of optics : electromagnetic theory of...')
       end
     end
 


### PR DESCRIPTION
Fixes https://github.com/sul-dlss/mylibrary/issues/963

There's probably a better long term solution where we wire up turbo/hotwire to show renewal response information rather than relying on flash. However, we're seeing a fair number of these errors and I'd like to get this fix out and defer other improvements to separate issues https://github.com/sul-dlss/mylibrary/issues/465 and https://github.com/sul-dlss/mylibrary/issues/466.