### PR TITLE
Remove code related to payment-in-process handling via cookies

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,13 +93,6 @@ Cybersource (a company owned by VISA) is our external payment processor for payi
 
 We currently support only one type of transaction: paying all of a user's payable fines together at once. When the user clicks the "pay all" button, we redirect their request to Cybersource via an interstitial form, which generates a POST request containing the data that sets up the checkout form along with a security signature. When the user completes their payment, Cybersource will POST some information back to us, including some of the information we originally sent which identifies the user and how much they paid. We pass this information to the ILS client to actually do the work of marking the fines as having been paid.
 
-In Symphony, the ILS may take some time to actually reflect the payment, so we use a strategy involving setting a cookie based on the user's browser session to filter out fines that have been paid but not yet reflected in the ILS. Otherwise, the user might think that their payment didn't go through, because the fines are still showing. Those fines will be filtered (not shown on the fines page) for that current user's in browser session for 10 minutes. We are assuming a few things:
-
-- That Symphony will resolve these transactions in at least 10 minutes
-- That the user won't be switching browsers and expect their payments to be filtered to in flight payments
-
-In FOLIO, the API request to mark a fine as paid is synchronous, so we don't need to worry about this.
-
 ## Testing
 
 The test suite (with RuboCop style enforcement) will be run with the default rake task (also run on travis)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -20,7 +20,7 @@ class ApplicationController < ActionController::Base
   def patron
     return unless current_user?
 
-    @patron ||= ils_patron_model_class.new(patron_info_response, payment_in_process_cookie)
+    @patron ||= ils_patron_model_class.new(patron_info_response)
   end
 
   def patron_or_group
@@ -58,14 +58,6 @@ class ApplicationController < ActionController::Base
 
   def symphony?
     Settings.ils.client == 'SymphonyClient'
-  end
-
-  ##
-  # Used in conjuction with Patron to determine if fines should be filtered by
-  # in flight payment sequence
-  # TODO: remove payment cookie methods when migration off of Symphony is complete
-  def payment_in_process_cookie
-    @payment_in_process_cookie ||= JSON.parse(cookies[:payment_in_process] || {}.to_json).with_indifferent_access
   end
 
   def patron_info_response

--- a/app/controllers/payments_controller.rb
+++ b/app/controllers/payments_controller.rb
@@ -30,8 +30,6 @@ class PaymentsController < ApplicationController
   #
   # POST /payments
   def create
-    # TODO: remove payment cookie methods when migration off of Symphony is complete
-    set_payment_cookie if ils_client.is_a? SymphonyClient
     @params = cybersource_request
 
     render 'cybersource_form', layout: false
@@ -41,8 +39,6 @@ class PaymentsController < ApplicationController
   #
   # POST /payments/accept
   def accept
-    # TODO: remove payment cookie methods when migration off of Symphony is complete
-    alter_payment_cookie if ils_client.is_a? SymphonyClient
     ils_client.pay_fines(user: cybersource_response.user,
                          amount: cybersource_response.amount,
                          session_id: cybersource_response.session_id)
@@ -56,8 +52,6 @@ class PaymentsController < ApplicationController
   #
   # POST /payments/cancel
   def cancel
-    # TODO: remove payment cookie methods when migration off of Symphony is complete
-    cookies.delete :payment_in_process if ils_client.is_a? SymphonyClient
     redirect_to fines_path, flash: { error: (t 'mylibrary.fine_payment.cancel_html') }
   end
 
@@ -69,36 +63,6 @@ class PaymentsController < ApplicationController
       key: 'payments',
       type: 'async',
       html: render_to_string(formats: [:html], layout: false)
-    }
-  end
-
-  ##
-  # Sets a cookie with information from the payment so that we can understand
-  # that there is a payment in flight
-  # TODO: remove payment cookie methods when migration off of Symphony is complete
-  def set_payment_cookie
-    cookies[:payment_in_process] = {
-      value: {
-        billseq: create_payment_params[:billseq],
-        session_id: create_payment_params[:session_id],
-        group: create_payment_params[:group]
-      }.to_json,
-      httponly: true,
-      expires: 10.minutes
-    }
-  end
-
-  ##
-  # On return from cybersource check the session_id to see if it checks out and
-  # then set the payment as "pending"
-  # TODO: remove payment cookie methods when migration off of Symphony is complete
-  def alter_payment_cookie
-    new_cookie = payment_in_process_cookie.dup
-    new_cookie[:pending] = true if new_cookie[:session_id] == cybersource_response.session_id
-    cookies[:payment_in_process] = {
-      value: new_cookie.to_json,
-      httponly: true,
-      expires: 10.minutes
     }
   end
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -51,7 +51,6 @@ class SessionsController < ApplicationController
   #
   # GET /logout
   def destroy
-    cookies.delete(:payment_in_process)
     needs_shibboleth_logout = current_user&.shibboleth?
     request.env['warden'].logout
 

--- a/app/models/folio/patron.rb
+++ b/app/models/folio/patron.rb
@@ -3,13 +3,12 @@
 module Folio
   # Class to model Patron information
   class Patron
-    attr_reader :patron_info, :payment_in_process
+    attr_reader :patron_info
 
     CHARGE_LIMIT_THRESHOLD = 25_000
 
-    def initialize(patron_info, payment_in_process = {})
+    def initialize(patron_info)
       @patron_info = patron_info
-      @payment_in_process = payment_in_process
     end
 
     # pass a FOLIO user uuid and get back a Patron object
@@ -150,11 +149,6 @@ module Folio
     # TODO: delete after FOLIO launch. All group payments are now affiliated with a single Sponsor patron.
     def group_payments
       []
-    end
-
-    # TODO: delete after FOLIO launch. No longer needed since we don't set a cookie for in-flight payments.
-    def payment_sequence
-      nil
     end
 
     def proxy_borrower?

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -34,12 +34,6 @@ RSpec.describe SessionsController do
       it 'redirects to the root' do
         expect(get(:destroy)).to redirect_to root_url
       end
-
-      it 'removes payment_in_process cookie' do
-        request.cookies['payment_in_process'] = true
-        get :destroy
-        expect(response.cookies['payment_in_process']).to be_nil
-      end
     end
   end
 

--- a/spec/models/symphony/patron_spec.rb
+++ b/spec/models/symphony/patron_spec.rb
@@ -462,37 +462,6 @@ RSpec.describe Symphony::Patron do
         expect(patron.group_fines).to include a_kind_of(Symphony::Fine).and(have_attributes(key: '1'))
       end
     end
-
-    context 'with a payment in process' do
-      subject(:patron_payment_in_process) do
-        described_class.new(
-          {
-            key: '1',
-            fields: fields
-          }.with_indifferent_access,
-          {
-            billseq: '3-5',
-            pending: true
-          }.with_indifferent_access
-        )
-      end
-
-      before do
-        fields[:blockList] = [{ key: '1:1', fields: {} }, { key: '2:4', fields: {} }]
-      end
-
-      describe '#fines' do
-        it 'only contains fines that are not in process' do
-          expect(patron_payment_in_process.fines).to have_attributes(length: 1)
-        end
-      end
-
-      describe '#all_fines' do
-        it 'contains all fines' do
-          expect(patron_payment_in_process.all_fines).to have_attributes(length: 2)
-        end
-      end
-    end
   end
 
   context 'with requests' do


### PR DESCRIPTION
When we paid fines using Symphony, it would sometimes take a long
time for that to be reflected in the user's account, so we used
a convoluted process involving setting a cookie after payment and
checking for it when rendering the list of fines so that we could
make them appear to have been paid already.

This removes that code (since it happens immediately in FOLIO) and
updates the README.
