### PR TITLE
Fix test descriptions and params

### DIFF
--- a/spec/controllers/requests_controller_spec.rb
+++ b/spec/controllers/requests_controller_spec.rb
@@ -98,14 +98,14 @@ RSpec.describe RequestsController do
         let(:mock_client) { instance_double(FolioClient, not_needed_after: api_response, ping: true) }
 
         it 'updates the not needed after and sets the flash message' do
-          patch :update, params: { resource: 'abc', id: '123', not_needed_after: '1999/01/01' }
+          patch :update, params: { resource: '123', id: '123', not_needed_after: '1999/01/01' }
 
           expect(flash[:success].first).to match(/Success!.*not needed after date was updated/)
         end
 
         it 'does not update the not needed after if dates are not changed' do
           patch :update, params: {
-            resource: 'abc', id: '123', not_needed_after: '1999/01/01', current_fill_by_date: '1999/01/01'
+            resource: '123', id: '123', not_needed_after: '1999/01/01', current_fill_by_date: '1999/01/01'
           }
 
           expect(flash[:success]).to eq []
@@ -115,22 +115,22 @@ RSpec.describe RequestsController do
       context 'with a group request' do
         let(:mock_client) { instance_double(FolioClient, change_pickup_library: api_response, ping: true) }
 
-        it 'renews the item and redirects to checkouts_path' do
+        it 'renews the item and redirects to requests_path' do
           patch :update, params: { resource: '123', id: '123', service_point: 'Other library', group: true }
 
           expect(response).to redirect_to requests_path(group: true)
         end
       end
 
-      context 'when the requested item is not available to the patron' do
+      context "when the request key does not match any of the patron's requests" do
         it 'does not renew the item and sets flash messages' do
-          patch :update, params: { resource: 'abc', id: 'some_made_up_item_key' }
+          patch :update, params: { resource: 'some_other_request_key', id: 'some_other_request_key' }
 
           expect(flash[:error]).to match('An unexpected error has occurred')
         end
 
-        it 'does not renew the item and redirects to checkouts_path' do
-          patch :update, params: { resource: 'abc', id: 'some_made_up_item_key' }
+        it 'does not renew the item and redirects to requests_path' do
+          patch :update, params: { resource: 'some_other_request_key', id: 'some_other_request_key' }
 
           expect(response).to redirect_to requests_path
         end
@@ -151,12 +151,12 @@ RSpec.describe RequestsController do
 
       context 'when everything is good' do
         it 'cancels the hold and sets flash messages' do
-          delete :destroy, params: { resource: 'abc', id: '123' }
+          delete :destroy, params: { resource: '123', id: '123' }
           expect(flash[:success]).to match(/Success!/)
         end
 
         it 'cancels the hold and redirects to requests_path' do
-          delete :destroy, params: { resource: 'abc', id: '123' }
+          delete :destroy, params: { resource: '123', id: '123' }
           expect(response).to redirect_to requests_path
         end
       end
@@ -165,34 +165,34 @@ RSpec.describe RequestsController do
         let(:api_response) { instance_double('Response', status: 401, content_type: :json, body: 'foo') }
 
         it 'does not cancel the hold and sets flash messages' do
-          delete :destroy, params: { resource: 'abc', id: '123' }
+          delete :destroy, params: { resource: '123', id: '123' }
           expect(flash[:error]).to match(/Sorry!/)
         end
 
-        it 'does not cancel the hold and redirects to checkouts_path' do
-          delete :destroy, params: { resource: 'abc', id: '123' }
+        it 'does not cancel the hold and redirects to requests_path' do
+          delete :destroy, params: { resource: '123', id: '123' }
           expect(response).to redirect_to requests_path
         end
       end
     end
 
     context 'with a group request' do
-      it 'renews the item and redirects to checkouts_path' do
-        delete :destroy, params: { resource: 'abc', id: '123', group: true }
+      it 'renews the item and redirects to requests_path' do
+        delete :destroy, params: { resource: '123', id: '123', group: true }
 
         expect(response).to redirect_to requests_path(group: true)
       end
     end
 
-    context 'when the requested item is not avaiable to the patron' do
+    context "when the request key does not match any of the patron's requests" do
       it 'does not renew the item and sets flash messages' do
-        delete :destroy, params: { resource: 'abc', id: 'some_made_up_item_key' }
+        delete :destroy, params: { resource: 'some_other_request_key', id: 'some_other_request_key' }
 
         expect(flash[:error]).to match('An unexpected error has occurred')
       end
 
-      it 'does not renew the item and redirects to checkouts_path' do
-        delete :destroy, params: { resource: 'abc', id: 'some_made_up_item_key' }
+      it 'does not renew the item and redirects to requests_path' do
+        delete :destroy, params: { resource: 'some_other_request_key', id: 'some_other_request_key' }
 
         expect(response).to redirect_to requests_path
       end
@@ -217,7 +217,7 @@ RSpec.describe RequestsController do
       warden.set_user(user)
     end
 
-    it 'assigns a list of checkouts' do
+    it 'assigns a list of requests' do
       get(:index, params: { group: true })
 
       expect(assigns(:requests)).to eq requests


### PR DESCRIPTION
Noticed a few issues with these tests as I was working on something else.

- In FOLIO resource and id are set to the same value
- There were various references to "checkout_path" that were likely copy pasta that should be "requests_path".
- Some references to "item" are more accurately "request" in FOLIO.