### PR TITLE
Drop Ruby 3.1 builds

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: ['3.1', '3.2']
+        ruby: ['3.2']
     steps:
     - uses: actions/checkout@v3
     - name: Set up Ruby


### PR DESCRIPTION
All environments are deployed on 3.2 now.