### PR TITLE
Let Capybara wait up to 10 seconds for flaky JS test

### DIFF
--- a/spec/features/checkouts_spec.rb
+++ b/spec/features/checkouts_spec.rb
@@ -101,10 +101,12 @@ RSpec.describe 'Checkout Page' do
         expect(page).to have_css('dd', text: '36105021987123', visible: :visible)
       end
 
-      within('ul.checkouts li:nth-child(1)') do
-        click_button 'Expand'
-        expect(page).to have_css('dt', text: 'Fines accrued:', visible: :visible)
-        expect(page).to have_css('dd', text: '$30.00', visible: :visible)
+      using_wait_time(10) do
+        within('ul.checkouts li:nth-child(1)') do
+          click_button 'Expand'
+          expect(page).to have_css('dt', text: 'Fines accrued:', visible: :visible)
+          expect(page).to have_css('dd', text: '$30.00', visible: :visible)
+        end
       end
     end
   end


### PR DESCRIPTION
Maybe there's a better way to deal with this? But this particular test has been very unreliable lately.