### PR TITLE
Remove unused lost? method on Folio::FolioRecord

### DIFF
--- a/app/models/concerns/folio/folio_record.rb
+++ b/app/models/concerns/folio/folio_record.rb
@@ -47,10 +47,6 @@ module Folio
       Folio::LocationsMap.for(item.dig('effectiveLocation', 'code'))&.last
     end
 
-    def lost?
-      current_location == 'LOST-ASSUM'
-    end
-
     private
 
     def item


### PR DESCRIPTION
We only care about whether Folio::Checkout objects are lost and it's defined correctly for FOLIO there.