### PR TITLE
removing interlibrary loan and scan links on requests page

### DIFF
--- a/app/views/requests/index.html.erb
+++ b/app/views/requests/index.html.erb
@@ -73,16 +73,6 @@
       <%= sul_icon :'sharp-open_in_new-24px' %> Aeon.
     <% end %>
     </li>
-    <li>Scan requests are listed in
-      <%= link_to 'https://sulils.stanford.edu/', target: '_blank' do %>
-        <%= sul_icon :'sharp-open_in_new-24px' %> Interlibrary Borrowing.
-      <% end %>
-    </li>
-    <li>Requests made through Stanford Libraries Interlibrary Services are listed in
-      <%= link_to 'https://sulils.stanford.edu/', target: '_blank' do %>
-        <%= sul_icon :'sharp-open_in_new-24px' %> Interlibrary Borrowing.
-      <% end %>
-    </li>
     <li>Requests requiring approval are not listed here until they have been approved &mdash; typically 1-3 days before your scheduled visit.</li>
   </ul>
 </div>


### PR DESCRIPTION
Closes #997 

What this pull request does:

Delete the two links in requests index.html.erb that pointed to https://sulils.stanford.edu/