### PR TITLE
not displaying inactive illiad requests based on transaction status

### DIFF
--- a/spec/models/illiad_requests_spec.rb
+++ b/spec/models/illiad_requests_spec.rb
@@ -33,11 +33,16 @@ RSpec.describe IlliadRequests do
       "ItemInfo4":"GREEN",
       "CallNumber":"DEF"}'
   end
+  let(:inactive_result) do
+    '{"TransactionNumber":123,
+      "Username":"sunet",
+      "TransactionStatus":"Cancelled by Customer"}'
+  end
   let(:transaction_results) do
-    "[#{hold_recall_result},#{scan_result}]"
+    "[#{hold_recall_result},#{scan_result},#{inactive_result}]"
   end
 
-  context 'when successful, it correctly retrieves transaction requests' do
+  context 'when successful, it retrieves transaction requests and ignores inactive requests' do
     before do
       stub_request(:get, "#{Settings.sul_illiad}ILLiadWebPlatform/Transaction/UserRequests/#{patron_sunet_id}")
         .to_return(status: 200, body: transaction_results, headers: {})


### PR DESCRIPTION
Closes #1001 .

What this pull request does:

Check for transaction status to belong to a specific set (which according to the spreadsheet in the linked issue indicates that that request should not be displayed).
If the transaction status in this set, the transaction is inactive.
When illiad requests are returned for the patron, inactive requests will not be included.