### PR TITLE
Rename "Library ID" to "University ID"

### DIFF
--- a/app/controllers/reset_pins_controller.rb
+++ b/app/controllers/reset_pins_controller.rb
@@ -21,7 +21,7 @@ class ResetPinsController < ApplicationController
   # POST /reset_pin
   def reset
     suppress ActiveRecord::RecordNotFound do
-      patron = FolioClient.new.find_patron_by_university_id(university_id_param, patron_info: false)
+      patron = FolioClient.new.find_patron_by_barcode_or_university_id(university_id_param, patron_info: false)
 
       ResetPinsMailer.with(patron:).reset_pin.deliver_now
     end

--- a/app/controllers/reset_pins_controller.rb
+++ b/app/controllers/reset_pins_controller.rb
@@ -16,17 +16,19 @@ class ResetPinsController < ApplicationController
   # a token for completing the reset
   #
   # Ignore errors indicating the patron wasn't found in the ILS; we don't want
-  # to leak information about presence/validity of library IDs
+  # to leak information about presence/validity of university IDs
   #
   # POST /reset_pin
   def reset
     suppress ActiveRecord::RecordNotFound do
-      patron = FolioClient.new.find_patron_by_barcode(library_id_param, patron_info: false)
+      patron = FolioClient.new.find_patron_by_university_id(university_id_param, patron_info: false)
 
       ResetPinsMailer.with(patron:).reset_pin.deliver_now
     end
 
-    flash[:success] = t 'mylibrary.reset_pin.success_html', library_id: params['library_id']
+    flash[:success] = t('mylibrary.reset_pin.success_html',
+                        university_id: params['university_id'],
+                        university_id_label: t('mylibrary.university_id.label'))
     redirect_to login_path
   end
 
@@ -48,8 +50,8 @@ class ResetPinsController < ApplicationController
 
   private
 
-  def library_id_param
-    params.require(:library_id)
+  def university_id_param
+    params.require(:university_id)
   end
 
   def change_pin_with_token_params

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -13,21 +13,21 @@ class SessionsController < ApplicationController
     redirect_to summaries_url if current_user?
   end
 
-  # Render a login form for Barcode + PIN users (Stanford single-sign-on are
+  # Render a login form for University ID + PIN users (Stanford single-sign-on are
   # authenticated using a different route)
   #
   # GET /login
   def form; end
 
-  # Handle login for Barcode + PIN users by authenticating them with the
+  # Handle login for University ID + PIN users by authenticating them with the
   # ILS using the Warden configuration.
   #
-  # GET /sessions/login_by_library_id
-  def login_by_library_id
-    if request.env['warden'].authenticate(:library_id)
+  # GET /sessions/login_by_university_id
+  def login_by_university_id
+    if request.env['warden'].authenticate(:university_id)
       redirect_to summaries_url
     else
-      redirect_to login_url, alert: t('mylibrary.sessions.login_by_library_id.alert')
+      redirect_to login_url, alert: t('mylibrary.sessions.login_by_university_id.alert')
     end
   end
 

--- a/app/services/folio_client.rb
+++ b/app/services/folio_client.rb
@@ -40,6 +40,12 @@ class FolioClient
   end
 
   def login(university_id, pin)
+    user_response = get_json('/users', params: { query: CqlQuery.new(barcode: university_id).to_query })
+    if (user = user_response.dig('users', 0))
+      return unless validate_patron_pin(user['id'], pin)
+
+      return user
+    end
     user_response = get_json('/users', params: { query: CqlQuery.new(externalSystemId: university_id).to_query })
     user = user_response.dig('users', 0)
 

--- a/app/services/folio_client.rb
+++ b/app/services/folio_client.rb
@@ -39,28 +39,53 @@ class FolioClient
     "#<#{self.class.name}:#{object_id}  @base_url=\"#{base_url}\">"
   end
 
-  def login(university_id, pin)
-    user_response = get_json('/users', params: { query: CqlQuery.new(barcode: university_id).to_query })
-    if (user = user_response.dig('users', 0))
-      return unless validate_patron_pin(user['id'], pin)
-
-      return user
-    end
-    user_response = get_json('/users', params: { query: CqlQuery.new(externalSystemId: university_id).to_query })
-    user = user_response.dig('users', 0)
-
-    return unless user && validate_patron_pin(user['id'], pin)
-
-    user
+  # Login by barcode or university ID, trying barcode first
+  # TODO: remove once we're no longer using barcodes for auth
+  def login_by_barcode_or_university_id(barcode_or_id, pin)
+    login_by_barcode(barcode_or_id, pin) || login_by_university_id(barcode_or_id, pin)
   end
 
+  # Find the user by barcode and validate their PIN, returning the user
+  def login_by_barcode(barcode, pin)
+    user = find_user_by_barcode(barcode)
+    user if validate_patron_pin(user['id'], pin)
+  rescue ActiveRecord::RecordNotFound
+    nil
+  end
+
+  # Find the user by university ID and validate their PIN, returning the user
+  def login_by_university_id(university_id, pin)
+    user = find_user_by_university_id(university_id)
+    user if validate_patron_pin(user['id'], pin)
+  rescue ActiveRecord::RecordNotFound
+    nil
+  end
+
+  # Find the user by sunetid and return them; auth handled by Shibboleth
   def login_by_sunetid(sunetid)
-    response = get_json('/users', params: { query: CqlQuery.new(username: sunetid).to_query })
-    response.dig('users', 0)
+    find_user_by_sunetid(sunetid)
+  rescue ActiveRecord::RecordNotFound
+    nil
   end
 
-  def user_info(user_id)
-    get_json("/users/#{CGI.escape(user_id)}")
+  # Find a Folio::Patron by barcode or university ID, trying barcode first
+  # TODO: remove once we're no longer using barcodes for auth
+  def find_patron_by_barcode_or_university_id(barcode_or_id, patron_info: true)
+    find_patron_by_barcode(barcode_or_id, patron_info:)
+  rescue ActiveRecord::RecordNotFound
+    find_patron_by_university_id(barcode_or_id, patron_info:)
+  end
+
+  # Find a Folio::Patron by barcode; fetch full patron info if patron_info is true
+  def find_patron_by_barcode(barcode, patron_info: true)
+    user = find_user_by_barcode(barcode)
+    patron_info ? Folio::Patron.find(user['id']) : Folio::Patron.new({ 'user' => user })
+  end
+
+  # Find a Folio::Patron by university ID; fetch full patron info if patron_info is true
+  def find_patron_by_university_id(university_id, patron_info: true)
+    user = find_user_by_university_id(university_id)
+    patron_info ? Folio::Patron.find(user['id']) : Folio::Patron.new({ 'user' => user })
   end
 
   # FOLIO graphql call, compare to #patron_account
@@ -215,6 +240,30 @@ class FolioClient
   end
 
   private
+
+  # Find a user by barcode in FOLIO; raise an error if not found
+  def find_user_by_barcode(barcode)
+    user = get_json('/users', params: { query: CqlQuery.new(barcode:).to_query }).dig('users', 0)
+    raise ActiveRecord::RecordNotFound, "User with barcode '#{barcode}' not found" unless user
+
+    user
+  end
+
+  # Find a user by university ID (externalSystemId in FOLIO); raise an error if not found
+  def find_user_by_university_id(university_id)
+    user = get_json('/users', params: { query: CqlQuery.new(externalSystemId: university_id).to_query }).dig('users', 0)
+    raise ActiveRecord::RecordNotFound, "User with externalSystemId '#{university_id}' not found" unless user
+
+    user
+  end
+
+  # Find a user by sunetid (username in FOLIO); raise an error if not found
+  def find_user_by_sunetid(sunetid)
+    user = get_json('/users', params: { query: CqlQuery.new(username: sunetid).to_query }).dig('users', 0)
+    raise ActiveRecord::RecordNotFound, "User with username '#{sunetid}' not found" unless user
+
+    user
+  end
 
   def update_request(request_id, request_data_updates)
     request_data = get_json("/circulation/requests/#{request_id}")

--- a/app/services/folio_client.rb
+++ b/app/services/folio_client.rb
@@ -39,8 +39,8 @@ class FolioClient
     "#<#{self.class.name}:#{object_id}  @base_url=\"#{base_url}\">"
   end
 
-  def login(library_id, pin)
-    user_response = get_json('/users', params: { query: CqlQuery.new(barcode: library_id).to_query })
+  def login(university_id, pin)
+    user_response = get_json('/users', params: { query: CqlQuery.new(externalSystemId: university_id).to_query })
     user = user_response.dig('users', 0)
 
     return unless user && validate_patron_pin(user['id'], pin)
@@ -170,16 +170,6 @@ class FolioClient
 
     response = post('/patron-pin', json: { id: patron_key, pin: new_pin })
     check_response(response, title: 'Assign pin', context: { user_id: patron_key })
-  end
-
-  # Look up a patron by barcode and return a Patron object
-  # If 'patron_info' is false, don't run the full patron info GraphQL query
-  def find_patron_by_barcode(barcode, patron_info: true)
-    response = get_json('/users', params: { query: CqlQuery.new(barcode:).to_query })
-    user = response.dig('users', 0)
-    raise ActiveRecord::RecordNotFound, "User with barcode #{barcode} not found" unless user
-
-    patron_info ? Folio::Patron.find(user['id']) : Folio::Patron.new({ 'user' => user })
   end
 
   # Mark all of a user's fines (accounts) as having been paid

--- a/app/views/reset_pins/change_form.html.erb
+++ b/app/views/reset_pins/change_form.html.erb
@@ -12,7 +12,7 @@
   <div class="form-group">
     <%= label_tag :pin, 'New PIN' %>
     <div class="input-group" data-showpassword="pin">
-      <%= password_field_tag :pin, nil, class: 'form-control', 'aria-describedby': 'libraryIdHelp', autofocus: true, autocomplete: 'off' %>
+      <%= password_field_tag :pin, nil, class: 'form-control', 'aria-describedby': 'new-pin-help', autofocus: true, autocomplete: 'off' %>
       <div class="input-group-append">
         <button class="btn btn-link" data-visibility disabled>
           <%= sul_icon(:'sharp-visibility-24px') %>
@@ -22,7 +22,7 @@
         </button>
       </div>
     </div>
-    <small id="libraryIdHelp" class="form-text text-muted">Your new PIN</small>
+    <small id="new-pin-help" class="form-text text-muted">Your new PIN</small>
   </div>
   <%= submit_tag 'Change PIN', class: 'btn btn-primary' %>
   <%= link_to 'Cancel', root_url, class: 'btn btn-link' %>

--- a/app/views/reset_pins/index.html.erb
+++ b/app/views/reset_pins/index.html.erb
@@ -1,9 +1,9 @@
 <h1>Reset/Request PIN</h1>
 <%= form_tag reset_pin_url, method: :post do %>
   <div class="form-group">
-    <%= label_tag :library_id, 'Library ID' %>
-    <%= text_field_tag :library_id, nil, class: 'form-control', 'aria-describedby': 'libraryIdHelp', autofocus: true %>
-    <small id="libraryIdHelp" class="form-text text-muted">Last 10 digits above the barcode on your library card</small>
+    <%= label_tag :university_id, t('mylibrary.university_id.label') %>
+    <%= text_field_tag :university_id, nil, class: 'form-control', 'aria-describedby': 'university-id-help', autofocus: true %>
+    <small id="university-id-help" class="form-text text-muted"><%= t('mylibrary.university_id.help_text') %></small>
   </div>
 
   <%= submit_tag 'Reset/Request PIN', class: 'btn btn-primary' %>

--- a/app/views/sessions/form.html.erb
+++ b/app/views/sessions/form.html.erb
@@ -1,10 +1,10 @@
 <h1><%= proxy_login_header %></h1>
-<%= form_tag login_by_library_id_url, method: :post do %>
+<%= form_tag login_by_university_id_url, method: :post do %>
 
   <div class="form-group">
-    <%= label_tag :library_id, 'Library ID' %>
-    <%= text_field_tag :library_id, nil, class: 'form-control col-8 col-sm-4', 'aria-describedby': 'libraryIdHelp', autofocus: true %>
-    <small id="libraryIdHelp" class="form-text text-muted">Last 10 digits above the barcode on your library card</small>
+    <%= label_tag :university_id, t('mylibrary.university_id.label') %>
+    <%= text_field_tag :university_id, nil, class: 'form-control col-8 col-sm-4', 'aria-describedby': 'university-id-help', autofocus: true %>
+    <small id="university-id-help" class="form-text text-muted"><%= t('mylibrary.university_id.help_text') %></small>
   </div>
 
   <div class="form-group">

--- a/config/initializers/warden.rb
+++ b/config/initializers/warden.rb
@@ -73,7 +73,7 @@ Warden::Strategies.add(:university_id) do
   end
 
   def authenticate!
-    response = FolioClient.new.login(params['university_id'], params['pin'])
+    response = FolioClient.new.login_by_barcode_or_university_id(params['university_id'], params['pin'])
 
     if response&.key?('patronKey') || response&.key?('id')
       u = { username: params['university_id'], patron_key: response['patronKey'] || response['id'] }

--- a/config/initializers/warden.rb
+++ b/config/initializers/warden.rb
@@ -64,9 +64,11 @@ Warden::Strategies.add(:university_id) do
   # * Courtesy card holders (the primary user group that we're trying to help
   #   gain access in sul-requests & My Account) have either 9 or 10 digits in
   #   FOLIO External System ID field.
+  #
+  # Until we're ready to completely roll out university ID login, we're also
+  # supporting the old library id (barcode) input.
   def valid?
     params['university_id'].present? &&
-      params['university_id'].match?(/\d{8,10}/) &&
       params['pin'].present?
   end
 

--- a/config/initializers/warden.rb
+++ b/config/initializers/warden.rb
@@ -54,16 +54,27 @@ Warden::Strategies.add(:development_shibboleth_stub) do
   end
 end
 
-Warden::Strategies.add(:library_id) do
+Warden::Strategies.add(:university_id) do
+  # Reviewing numbers input in the FOLIO "External System ID", it appears that
+  # we have user records with 8, 9 and 10 digits.
+  #
+  # * Core community users (who presumably would be accessing our applications
+  #   using auth and NOT inputting an ID) have 8 digits in the FOLIO External
+  #   System ID field
+  # * Courtesy card holders (the primary user group that we're trying to help
+  #   gain access in sul-requests & My Account) have either 9 or 10 digits in
+  #   FOLIO External System ID field.
   def valid?
-    params['library_id'].present? && params['pin'].present?
+    params['university_id'].present? &&
+      params['university_id'].match?(/\d{8,10}/) &&
+      params['pin'].present?
   end
 
   def authenticate!
-    response = FolioClient.new.login(params['library_id'], params['pin'])
+    response = FolioClient.new.login(params['university_id'], params['pin'])
 
     if response&.key?('patronKey') || response&.key?('id')
-      u = { username: params['library_id'], patron_key: response['patronKey'] || response['id'] }
+      u = { username: params['university_id'], patron_key: response['patronKey'] || response['id'] }
       success!(User.new(u))
     else
       fail!('Could not log in')

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -38,6 +38,9 @@ en:
       time_tomorrow: 'Tomorrow at %-l:%M%P'
   hello: "Hello world"
   mylibrary:
+    university_id:
+      label: 'University ID'
+      help_text: 'This is an 8- to 10-digit number that serves as a replacement for the Library ID that was previously utilized.'
     renew_item:
       success_html: <span class="font-weight-bold">Success!</span> "%{title}" was renewed.
       error_html: <span class="font-weight-bold">Sorry!</span> Something went wrong and "%{title}" was not renewed.
@@ -64,7 +67,7 @@ en:
       success_html: <span class="font-weight-bold">Success!</span> Your new PIN is ready to use.
       invalid_token_html: <span class="font-weight-bold">Sorry!</span> That reset PIN link is invalid or expired. Enter your library ID to request a new link.
     reset_pin:
-      success_html: <span class="font-weight-bold">Check your email!</span> A PIN reset link has been sent to the address associated with library ID %{library_id}
+      success_html: <span class="font-weight-bold">Check your email!</span> A PIN reset link has been sent to the address associated with %{university_id_label} %{university_id}
       request_failed_html: <span class="font-weight-bold">Sorry!</span> Something went wrong, possibly due to a connection failure. Try again or contact us for help.
     reset_pins_mailer:
       reset_pin:
@@ -83,7 +86,7 @@ en:
       request_failed_html: <span class="font-weight-bold">Sorry!</span> Something went wrong, possibly due to a connection failure. Please <a href="mailto:sul-privileges@stanford.edu">contact us</a> for help resolving your fines.
       payment_failed_html: <span class="font-weight-bold">Sorry!</span> Payment failed. Please <a href="mailto:sul-privileges@stanford.edu">contact us</a> for help resolving your fines.
     sessions:
-      login_by_library_id:
+      login_by_university_id:
         alert: Unable to authenticate.
       login_by_sunetid:
         error_html: <p class="h3">Unable to log in. Your SUNet ID is not linked to a library account.</p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -39,8 +39,8 @@ en:
   hello: "Hello world"
   mylibrary:
     university_id:
-      label: 'University ID'
-      help_text: 'This is an 8- to 10-digit number that serves as a replacement for the Library ID that was previously utilized.'
+      label: 'Library ID'
+      help_text: 'Last 10 digits above the barcode on your library card'
     renew_item:
       success_html: <span class="font-weight-bold">Success!</span> "%{title}" was renewed.
       error_html: <span class="font-weight-bold">Sorry!</span> Something went wrong and "%{title}" was not renewed.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,7 +20,7 @@ Rails.application.routes.draw do
   get 'feedback' => 'feedback_forms#new'
 
   get '/sessions/login_by_sunetid', to: 'sessions#login_by_sunetid', as: :login_by_sunetid
-  post '/sessions/login_by_library_id', to: 'sessions#login_by_library_id', as: :login_by_library_id
+  post '/sessions/login_by_university_id', to: 'sessions#login_by_university_id', as: :login_by_university_id
   get '/login', to: 'sessions#form', as: :login
   get '/logout', to: 'sessions#destroy', as: :logout
 

--- a/spec/controllers/reset_pins_controller_spec.rb
+++ b/spec/controllers/reset_pins_controller_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe ResetPinsController do
-  let(:mock_client) { instance_double(FolioClient, find_patron_by_university_id: patron, ping: true) }
+  let(:mock_client) { instance_double(FolioClient, find_patron_by_barcode_or_university_id: patron, ping: true) }
   let(:patron) do
     instance_double(Folio::Patron, display_name: 'Patron', barcode: 'PATRON', email: 'patron@example.com',
                                    pin_reset_token: 'abcdef')

--- a/spec/controllers/reset_pins_controller_spec.rb
+++ b/spec/controllers/reset_pins_controller_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe ResetPinsController do
       it 'sets flash messages' do
         post :reset, params: { university_id: '123456789' }
 
-        expect(flash[:success]).to match(/associated with University ID 123456789/)
+        expect(flash[:success]).to match(/associated with (University|Library) ID 123456789/)
       end
     end
   end

--- a/spec/controllers/reset_pins_controller_spec.rb
+++ b/spec/controllers/reset_pins_controller_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe ResetPinsController do
-  let(:mock_client) { instance_double(FolioClient, find_patron_by_barcode: patron, ping: true) }
+  let(:mock_client) { instance_double(FolioClient, find_patron_by_university_id: patron, ping: true) }
   let(:patron) do
     instance_double(Folio::Patron, display_name: 'Patron', barcode: 'PATRON', email: 'patron@example.com',
                                    pin_reset_token: 'abcdef')
@@ -34,13 +34,15 @@ RSpec.describe ResetPinsController do
   context 'with unauthenticated requests' do
     describe '#reset' do
       it 'sends the reset pin email' do
-        expect { post :reset, params: { library_id: '123456' } }.to change { ActionMailer::Base.deliveries.count }.by(1)
+        expect { post :reset, params: { university_id: '123456789' } }
+          .to change { ActionMailer::Base.deliveries.count }
+          .by(1)
       end
 
       it 'sets flash messages' do
-        post :reset, params: { library_id: '123456' }
+        post :reset, params: { university_id: '123456789' }
 
-        expect(flash[:success]).to match(/associated with library ID 123456/)
+        expect(flash[:success]).to match(/associated with University ID 123456789/)
       end
     end
   end

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -83,30 +83,31 @@ RSpec.describe SessionsController do
     end
   end
 
-  describe 'POST login_by_library_id' do
+  describe 'POST login_by_university_id' do
     context 'with a valid login' do
       before do
-        allow(mock_client).to receive(:login).with('abc', '123').and_return('patronKey' => 1)
+        allow(mock_client).to receive(:login).with('01234567', '123').and_return('patronKey' => 1)
       end
 
       it 'logs in the user' do
-        post(:login_by_library_id, params: { library_id: 'abc', pin: '123' })
+        post(:login_by_university_id, params: { university_id: '01234567', pin: '123' })
 
-        expect(warden.user).to have_attributes username: 'abc', patron_key: 1
+        expect(warden.user).to have_attributes username: '01234567', patron_key: 1
       end
 
       it 'redirects the user to the summary page' do
-        expect(post(:login_by_library_id, params: { library_id: 'abc', pin: '123' })).to redirect_to summaries_url
+        expect(post(:login_by_university_id, params: { university_id: '01234567', pin: '123' }))
+          .to redirect_to summaries_url
       end
     end
 
     context 'with an invalid login' do
       it 'redirects failed requests back to the login page' do
-        expect(post(:login_by_library_id)).to redirect_to login_url
+        expect(post(:login_by_university_id)).to redirect_to login_url
       end
 
       it 'sets an alert' do
-        get(:login_by_library_id)
+        get(:login_by_university_id)
         expect(flash[:alert]).to include('Unable to authenticate.')
       end
     end

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -86,7 +86,8 @@ RSpec.describe SessionsController do
   describe 'POST login_by_university_id' do
     context 'with a valid login' do
       before do
-        allow(mock_client).to receive(:login).with('01234567', '123').and_return('patronKey' => 1)
+        allow(mock_client).to receive(:login_by_barcode_or_university_id)
+          .with('01234567', '123').and_return('patronKey' => 1)
       end
 
       it 'logs in the user' do

--- a/spec/features/reset_pin_spec.rb
+++ b/spec/features/reset_pin_spec.rb
@@ -3,7 +3,9 @@
 require 'rails_helper'
 
 RSpec.describe 'Reset Pin' do
-  let(:mock_client) { instance_double(FolioClient, find_patron_by_university_id: patron, ping: true, change_pin: nil) }
+  let(:mock_client) do
+    instance_double(FolioClient, find_patron_by_barcode_or_university_id: patron, ping: true, change_pin: nil)
+  end
   let(:patron) do
     instance_double(Folio::Patron, email: 'jdoe@stanford.edu', display_name: 'J Doe', barcode: '123',
                                    pin_reset_token: 'foo')

--- a/spec/features/reset_pin_spec.rb
+++ b/spec/features/reset_pin_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Reset Pin' do
-  let(:mock_client) { instance_double(FolioClient, find_patron_by_barcode: patron, ping: true, change_pin: nil) }
+  let(:mock_client) { instance_double(FolioClient, find_patron_by_university_id: patron, ping: true, change_pin: nil) }
   let(:patron) do
     instance_double(Folio::Patron, email: 'jdoe@stanford.edu', display_name: 'J Doe', barcode: '123',
                                    pin_reset_token: 'foo')
@@ -26,7 +26,7 @@ RSpec.describe 'Reset Pin' do
 
   it 'allows user to reset pin' do
     visit reset_pin_path
-    fill_in('library_id', with: '123456')
+    fill_in('university_id', with: '123456')
     click_on 'Reset/Request PIN'
     expect(page).to have_css '.flash_messages', text: 'Check your email!'
   end


### PR DESCRIPTION
Connects to sul-dlss/SearchWorks#3773

This commit helps us move the access portfolio beyond using library barcode numbers, leaning instead on the university-assigned and -managed "university ID."
