### PR TITLE
Remove FolioRecord#resource method that was added for parity with Symphony; no longer used.

### DIFF
--- a/app/models/concerns/folio/folio_record.rb
+++ b/app/models/concerns/folio/folio_record.rb
@@ -34,12 +34,6 @@ module Folio
       item['barcode']
     end
 
-    def resource
-      # ? FOLIO: This was required for Symphony renew_item requests.
-      #     Setting this to the instanceId for now.
-      bib['instanceId']
-    end
-
     def item_key
       bib['itemId']
     end

--- a/app/views/checkouts/_checkout.json.jbuilder
+++ b/app/views/checkouts/_checkout.json.jbuilder
@@ -15,7 +15,6 @@ json.attributes do
   json.renewable checkout.renewable?
   json.renewable_at checkout.renewable_at
   json.renew_from_period checkout.renew_from_period
-  json.resource checkout.resource
   json.item_key checkout.item_key
   json.overdue checkout.overdue?
   json.accrued checkout.accrued

--- a/spec/controllers/renewals_controller_spec.rb
+++ b/spec/controllers/renewals_controller_spec.rb
@@ -23,19 +23,19 @@ RSpec.describe RenewalsController do
   end
 
   describe '#create' do
-    it 'requires resource and item_key params' do
+    it 'requires item_key params' do
       expect { post :create, params: {} }.to raise_error(ActionController::ParameterMissing)
     end
 
     context 'when everything is good' do
       it 'renews the item and sets flash messages' do
-        post :create, params: { resource: 'abc', item_key: '123' }
+        post :create, params: { item_key: '123' }
 
         expect(flash[:success]).to match(/Success!/)
       end
 
       it 'renews the item and redirects to checkouts_path' do
-        post :create, params: { resource: 'abc', item_key: '123' }
+        post :create, params: { item_key: '123' }
 
         expect(response).to redirect_to checkouts_path
       end
@@ -45,13 +45,13 @@ RSpec.describe RenewalsController do
       let(:api_response) { instance_double('Response', status: 401, content_type: :json) }
 
       it 'does not renew the item and sets flash messages' do
-        post :create, params: { resource: 'abc', item_key: '123' }
+        post :create, params: { item_key: '123' }
 
         expect(flash[:error]).to match(/Sorry!/)
       end
 
       it 'does not renew the item and redirects to checkouts_path' do
-        post :create, params: { resource: 'abc', item_key: '123' }
+        post :create, params: { item_key: '123' }
 
         expect(response).to redirect_to checkouts_path
       end
@@ -59,7 +59,7 @@ RSpec.describe RenewalsController do
 
     context 'with a group request' do
       it 'renews the item and redirects to checkouts_path' do
-        post :create, params: { resource: 'abc', item_key: '123', group: true }
+        post :create, params: { item_key: '123', group: true }
 
         expect(response).to redirect_to checkouts_path(group: true)
       end
@@ -67,13 +67,13 @@ RSpec.describe RenewalsController do
 
     context 'when the requested item is not checked out to the patron' do
       it 'does not renew the item and sets flash messages' do
-        post :create, params: { resource: 'abc', item_key: 'some_made_up_item_key' }
+        post :create, params: { item_key: 'some_made_up_item_key' }
 
         expect(flash[:error]).to match('An unexpected error has occurred')
       end
 
       it 'does not renew the item and redirects to checkouts_path' do
-        post :create, params: { resource: 'abc', item_key: 'some_made_up_item_key' }
+        post :create, params: { item_key: 'some_made_up_item_key' }
 
         expect(response).to redirect_to checkouts_path
       end
@@ -83,7 +83,7 @@ RSpec.describe RenewalsController do
       let(:checkouts) { [instance_double(Folio::Checkout, item_key: '123', item_category_non_renewable?: true)] }
 
       it 'does not renew the item and sets flash messages' do
-        post :create, params: { resource: 'abc', item_key: '123' }
+        post :create, params: { item_key: '123' }
 
         expect(flash[:error]).to match('An unexpected error has occurred')
       end
@@ -98,14 +98,11 @@ RSpec.describe RenewalsController do
     let(:mock_patron) { instance_double(Folio::Patron, checkouts:) }
     let(:checkouts) do
       [
-        instance_double(Folio::Checkout, key: '1', renewable?: true, item_key: '123', title: 'ABC',
-                                         resource: 'item'),
+        instance_double(Folio::Checkout, key: '1', renewable?: true, item_key: '123', title: 'ABC'),
         instance_double(Folio::Checkout, key: '2', renewable?: true, item_key: '456',
                                          title: 'Principles of optics : electromagnetic theory of ' \
-                                                'propagation, interference and diffraction of light',
-                                         resource: 'item'),
-        instance_double(Folio::Checkout, key: '3', renewable?: false, item_key: '789', title: 'Not',
-                                         resource: 'item')
+                                                'propagation, interference and diffraction of light'),
+        instance_double(Folio::Checkout, key: '3', renewable?: false, item_key: '789', title: 'Not')
       ]
     end
 

--- a/spec/features/renew_item_spec.rb
+++ b/spec/features/renew_item_spec.rb
@@ -18,8 +18,7 @@ RSpec.describe 'Renew item', :js do
 
   let(:api_response) { instance_double('Response', status: 201, content_type: :json) }
   let(:bulk_renew_response) do
-    { success: [instance_double(Folio::Checkout, key: '1', renewable?: true, item_key: '123', title: 'ABC',
-                                                 resource: 'item')] }
+    { success: [instance_double(Folio::Checkout, key: '1', renewable?: true, item_key: '123', title: 'ABC')] }
   end
 
   before do

--- a/spec/models/concerns/folio/folio_record.rb
+++ b/spec/models/concerns/folio/folio_record.rb
@@ -46,10 +46,6 @@ RSpec.shared_examples 'folio_record' do |args = []|
     it { expect(model.barcode).to eq '36105110374977' }
   end
 
-  describe '#resource' do
-    it { expect(model.resource).to eq '948b80ac-a7fa-5577-87b4-7494ee4c7482' }
-  end
-
   describe '#item_key' do
     it { expect(model.item_key).to eq '6d9a4f99-d144-51cf-92d7-3edbfc588abe' }
   end

--- a/spec/views/checkouts/_checkout.html.erb_spec.rb
+++ b/spec/views/checkouts/_checkout.html.erb_spec.rb
@@ -28,7 +28,6 @@ RSpec.describe 'checkouts/_checkout' do
       recalled_date: nil,
       renewable?: false,
       renewal_date: nil,
-      resource: nil,
       short_term_loan?: false,
       sort_key: nil,
       title: 'Checkout Title',

--- a/spec/views/requests/edit.html.erb_spec.rb
+++ b/spec/views/requests/edit.html.erb_spec.rb
@@ -9,7 +9,6 @@ RSpec.describe 'requests/edit' do
       Folio::Request,
       title: 'Request Title',
       key: 'abc123',
-      resource: nil,
       fill_by_date: nil,
       service_point_id: 'a5dbb3dc-84f8-4eb3-8bfe-c61f74a9e92d',
       restricted_pickup_service_points: [],


### PR DESCRIPTION
Folio only requires the item id for renewals whereas Symphony required the bib record id (instance id). This is no longer used or needed.