### PR TITLE
Remove fee/fine conditions for proxy groups that do not apply in FOLIO

### DIFF
--- a/app/models/folio/group.rb
+++ b/app/models/folio/group.rb
@@ -40,8 +40,10 @@ module Folio
       sponsor.group_checkouts || []
     end
 
+    # NOTE: Fines on items borrowed by a proxy/group are associated
+    # with the sponsor's individual account.
     def fines
-      sponsor.group_fines
+      []
     end
 
     def requests

--- a/app/models/folio/patron.rb
+++ b/app/models/folio/patron.rb
@@ -126,16 +126,6 @@ module Folio
       all_accounts.select(&:closed?)
     end
 
-    # TODO: delete after FOLIO launch. All group fines are now affiliated with a single Sponsor patron.
-    def group_fines
-      []
-    end
-
-    # TODO: delete after FOLIO launch. All group payments are now affiliated with a single Sponsor patron.
-    def group_payments
-      []
-    end
-
     def proxy_borrower?
       user_info['proxiesFor']&.any?
     end

--- a/app/views/fines/index.html.erb
+++ b/app/views/fines/index.html.erb
@@ -9,49 +9,28 @@
   <h2>Payable: <%= number_to_currency(@fines.sum(&:owed)) %></h2>
 
   <% if @fines.any? %>
-  <%# TODO: after FOLIO launch remove this condition %>
-  <% if params[:group] && patron.sponsor? %>
-  <div class="pb-3">
-      Fines can be paid in My Library Account only by the borrower who accrued them. <br />
-      To pay proxy fines using iJournal,
-      <%= link_to contact_path, data: { 'mylibrary-modal' => 'trigger' } do %>
-        contact Circulation & Privileges.
-      contact Circulation & Privileges.
-      <% end %>
-  </div>
-  <%# The user is a Proxy; the fine is not shown and must be paid in the Sponsor account %>
-  <% elsif params[:group] %>
-  <div class="pb-3">
-    <%= sul_icon :'sharp-error-24px', classes: 'text-recalled' %> The research group has unpaid fines that may affect
-    the status of all proxies.
-  </div>
-  <%# The user has fines on their personal account and can pay here %>
-  <% else %>
-  <div class="mb-3">
-    <%= render 'fines/shared_computer_alert' %>
-    <%= render 'fines/pay_all_button' %>
-  </div>
+    <div class="mb-3">
+      <%= render 'fines/shared_computer_alert' %>
+      <%= render 'fines/pay_all_button' %>
+    </div>
+
+    <div class="d-none d-md-flex row font-weight-bold list-header">
+      <div class="row col-md-4">
+        <div class="col-md-12 col-lg-6">Reason</div>
+        <div class="col-md-12 col-lg-6">Amount</div>
+      </div>
+      <div class="col-md-5">Title</div>
+      <div class="row col-md-3">
+        <div class="col-md-12 col-lg-6">Author</div>
+        <div class="col-md-12 col-lg-6 call_number">Call number</div>
+      </div>
+    </div>
+    <ul class="fines list-group">
+      <%= render @fines %>
+    </ul>
   <% end %>
 
-  <% unless params[:group] && !patron.sponsor? %>
-  <div class="d-none d-md-flex row font-weight-bold list-header">
-    <div class="row col-md-4">
-      <div class="col-md-12 col-lg-6">Reason</div>
-      <div class="col-md-12 col-lg-6">Amount</div>
-    </div>
-    <div class="col-md-5">Title</div>
-    <div class="row col-md-3">
-      <div class="col-md-12 col-lg-6">Author</div>
-      <div class="col-md-12 col-lg-6 call_number">Call number</div>
-    </div>
-  </div>
-  <ul class="fines list-group">
-    <%= render @fines %>
-  </ul>
-  <% end %>
-  <% end %>
-  <%# TODO: after FOLIO launch remove the Folio::Patron part of this condition %>
-  <% if patron.is_a?(Folio::Patron) && params[:group] && patron.sponsor? %>
+  <% if params[:group] && patron.sponsor? %>
     Fines incurred by proxy borrowers appear in the list of fines under their sponsor's Self tab.
   <% end %>
 </div>

--- a/app/views/summaries/_summary.html.erb
+++ b/app/views/summaries/_summary.html.erb
@@ -29,29 +29,12 @@
 
 <div class="page-section">
   <h3><%= sul_icon :'sharp-attach_money-24px', classes: 'lg' %> Fines &amp; fees payable: <%= number_to_currency(patron.fines.sum(&:owed)) %></h3>
-  <%# TODO: after FOLIO launch remove this condition %>
-  <% if params[:group] && patron.fines.sum(&:owed).positive? %>
-    <% if patron.sponsor? %>
-      <div class="ml-4">
-          Fines can be paid in My Library Account only by the borrower who accrued them. <br />
-          To pay proxy fines using iJournal,
-          <%= link_to contact_path, data: { 'mylibrary-modal' => 'trigger' } do %>
-          contact Circulation & Privileges.
-          <% end %>
-      </div>
-    <% else %>
-      <div class="ml-4">
-        <%= sul_icon :'sharp-error-24px', classes: 'text-recalled' %> The research group has unpaid fines that may affect the status of all proxies.
-      </div>
-    <% end %>
-  <% else %>
-    <div class="mb-1">
-      <%= render 'fines/shared_computer_alert' %>
-      <%= render 'fines/pay_all_button' %>
-    </div>
-  <% end %>
-  <%# TODO: after FOLIO launch remove the Folio::Patron part of this condition %>
-  <% if patron.is_a?(Folio::Patron) && params[:group] && patron.sponsor?%>
+  <div class="mb-1">
+    <%= render 'fines/shared_computer_alert' %>
+    <%= render 'fines/pay_all_button' %>
+  </div>
+
+  <% if params[:group] && patron.sponsor?%>
     Fines incurred by proxy borrowers appear in the list of fines under their sponsor's Self tab.
   <% end %> 
 


### PR DESCRIPTION
In FOLIO fines on items borrowed by a proxy are associated with the sponsor's individual account. We never display these fines when the proxy views their group activity and the fines display on the "Self" tab for the sponsor. None of the conditions in the related fine/summary views that check for both fines and the group parameter being set will ever be true. These conditions existed for Symphony. We can now remove the conditionals and the Symphony-only displays.