### PR TITLE
add axe spec, update accessibility so tests pass

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,6 +65,7 @@ end
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
+  gem 'axe-core-rspec'
   gem 'capybara'
   gem 'debug', platforms: %i[mri mingw x64_mingw]
   gem 'factory_bot_rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,6 +80,17 @@ GEM
     airbrussh (1.5.1)
       sshkit (>= 1.6.1, != 1.7.0)
     ast (2.4.2)
+    axe-core-api (4.8.2)
+      dumb_delegator
+      virtus
+    axe-core-rspec (4.8.2)
+      axe-core-api
+      dumb_delegator
+      virtus
+    axiom-types (0.1.1)
+      descendants_tracker (~> 0.0.4)
+      ice_nine (~> 0.11.0)
+      thread_safe (~> 0.3, >= 0.3.1)
     base64 (0.2.0)
     bigdecimal (3.1.6)
     bindex (0.8.1)
@@ -119,6 +130,8 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    coercible (1.0.0)
+      descendants_tracker (~> 0.0.1)
     concurrent-ruby (1.2.3)
     config (5.3.0)
       deep_merge (~> 1.2, >= 1.2.1)
@@ -134,6 +147,8 @@ GEM
       irb (~> 1.10)
       reline (>= 0.3.8)
     deep_merge (1.2.2)
+    descendants_tracker (0.0.4)
+      thread_safe (~> 0.3, >= 0.3.1)
     diff-lcs (1.5.1)
     dlss-capistrano (4.4.0)
       capistrano (~> 3.0)
@@ -143,6 +158,7 @@ GEM
     docile (1.4.0)
     domain_name (0.6.20240107)
     drb (2.2.1)
+    dumb_delegator (1.0.0)
     erubi (1.12.0)
     factory_bot (6.4.6)
       activesupport (>= 5.0.0)
@@ -178,6 +194,7 @@ GEM
     httpclient (2.8.3)
     i18n (1.14.4)
       concurrent-ruby (~> 1.0)
+    ice_nine (0.11.2)
     io-console (0.7.2)
     irb (1.12.0)
       rdoc
@@ -390,6 +407,7 @@ GEM
       net-ssh (>= 2.8.0)
     stringio (3.1.0)
     thor (1.3.1)
+    thread_safe (0.3.6)
     tilt (2.3.0)
     timecop (0.9.8)
     timeout (0.4.1)
@@ -400,6 +418,10 @@ GEM
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.5.0)
     uri (0.13.0)
+    virtus (2.0.0)
+      axiom-types (~> 0.1)
+      coercible (~> 1.0)
+      descendants_tracker (~> 0.0, >= 0.0.3)
     warden (1.2.9)
       rack (>= 2.0.9)
     warden-rspec-rails (0.3.0)
@@ -426,6 +448,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  axe-core-rspec
   bootsnap (>= 1.1.0)
   borrow_direct
   capistrano (~> 3.0)

--- a/app/assets/stylesheets/base.scss
+++ b/app/assets/stylesheets/base.scss
@@ -15,6 +15,10 @@ a {
   }
 }
 
+a[target="_blank"], p a, form a{
+  border-bottom: 1px solid $bright-blue;
+}
+
 :disabled {
   // scss-lint:disable ImportantRule
   background-color: $sul-btn-disabled-color !important;

--- a/app/assets/stylesheets/modules/global-alert.scss
+++ b/app/assets/stylesheets/modules/global-alert.scss
@@ -11,3 +11,7 @@
   @extend .global-alert;
   width: fit-content;
 }
+
+.alert-info a {
+  color: inherit;
+}

--- a/app/views/feedback_forms/new.html.erb
+++ b/app/views/feedback_forms/new.html.erb
@@ -1,1 +1,2 @@
+<h1>Provide feedback</h1>
 <%= render 'shared/feedback_forms/form' %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -40,7 +40,6 @@
       </div> <!-- #su-content end -->
     </div> <!-- #su-wrap end -->
     <%= render '/shared/sul_footer' %>
-    <%= render '/shared/global_footer' %>
     <%= render partial: 'shared/modal' %>
   </body>
 </html>

--- a/app/views/payments/index.html.erb
+++ b/app/views/payments/index.html.erb
@@ -1,7 +1,7 @@
 <div id="payments" class="page-section">
   <% if @payments.any? %>
     <div class="d-flex justify-content-between">
-      <h2>History</h2>
+      <h1 class="h2">History</h1>
       <div class="dropdown">
         <a class="btn btn-secondary dropdown-toggle" href="#" role="button" id="dropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
           Sort (<span data-sort-label>Date paid</span>)
@@ -16,7 +16,7 @@
       </div>
     </div>
   <% else %>
-    <h2>History</h2>
+    <h1 class="h2">History</h1>
     <span>There is no history on this account.</span>
   <% end %>
 

--- a/app/views/sessions/index.html.erb
+++ b/app/views/sessions/index.html.erb
@@ -41,8 +41,7 @@
     A library account is not required to access Stanford's e-resources. <br />
     Find e-resources in
     <%= link_to 'https://searchworks.stanford.edu', target: '_blank' do %>
-      <%= sul_icon :'sharp-open_in_new-24px' %> SearchWorks
-    <% end %>
-    and log in there with your SUNet ID.
+      <%= sul_icon :'sharp-open_in_new-24px' %> SearchWorks<% end %> and
+      log in there with your SUNet ID.
   </p>
 </div>

--- a/app/views/shared/_global_footer.html.erb
+++ b/app/views/shared/_global_footer.html.erb
@@ -1,5 +1,5 @@
 <!-- Global footer snippet start -->
-<div id="global-footer" role="contentinfo">
+<div id="global-footer">
   <div class="container">
     <div class="row">
       <div id="bottom-logo" class="col-sm-2">

--- a/app/views/shared/_sul_footer.html.erb
+++ b/app/views/shared/_sul_footer.html.erb
@@ -1,4 +1,4 @@
-<footer role="contentinfo">
+<footer>
   <div id="sul-footer-container">
     <div id="sul-footer" class="container">
       <div id="sul-footer-img" class="span2">
@@ -16,4 +16,5 @@
       </div>
     </div>
   </div>
+  <%= render '/shared/global_footer' %>
 </footer>

--- a/app/views/shared/_unavailable.html.erb
+++ b/app/views/shared/_unavailable.html.erb
@@ -1,5 +1,5 @@
 <div class="page-section">
-    <h2>Temporarily unavailable</h2>
+    <h1 class="h2">Temporarily unavailable</h1>
     <p>We're sorry, My Library Account is unavailable while its underlying systems are undergoing maintenance. </p>
     <p>If you need help with your account, email <a href="mailto:greencirc@stanford.edu">greencirc@stanford.edu</a> or call (650) 723-1493.</p>
 </div>

--- a/app/views/shared/contact_forms/_form.html.erb
+++ b/app/views/shared/contact_forms/_form.html.erb
@@ -1,10 +1,10 @@
 <div class="modal-header">
-  <h2 id="contactForm" class="clamp-1">
+  <h1 id="contactForm" class="clamp-1 h2">
     Contact <%= params[:library] ? 'library' : 'Circulation & Privileges' %>
-  </h2>
+  </h1>
 </div>
 <div class="modal-body">
-  <%= form_tag contact_path, method: :post, class: 'contact-form', role: 'form' do %>
+  <%= form_tag contact_path, method: :post, class: 'contact-form' do %>
     <%= hidden_field_tag :contact_form_to, library_email(params[:library]) %>
     <dl class="row">
       <dt class="col-2">Source:</dt>

--- a/app/views/shared/feedback_forms/_form.html.erb
+++ b/app/views/shared/feedback_forms/_form.html.erb
@@ -1,5 +1,5 @@
 <div class="container">
-  <%= form_tag feedback_form_path, method: :post, class:"feedback-form", role:"form" do %>
+  <%= form_tag feedback_form_path, method: :post, class:"feedback-form" do %>
     <div class="row mt-4">
       <div class="offset-md-2 col-md-8 mb-2">
         <%= render "shared/feedback_forms/reporting_from" %>

--- a/spec/features/axe_spec.rb
+++ b/spec/features/axe_spec.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'axe-rspec'
+
+RSpec.describe 'Accessibility testing', :js do
+  let(:mock_client) { instance_double(FolioClient, ping: true) }
+
+  let(:patron_info) do
+    {
+      'user' => { 'active' => true, 'manualBlocks' => [], 'blocks' => [],
+                  'personal' => { 'firstName' => 'Stub' } },
+      'loans' => [],
+      'holds' => [],
+      'accounts' => []
+    }
+  end
+
+  let(:user) do
+    { username: 'somesunetid', 'patronKey' => '123' }
+  end
+
+  before do
+    allow(FolioClient).to receive(:new).and_return(mock_client)
+    allow(mock_client).to receive_messages(patron_info:)
+    login_as(username: 'stub_user', patron_key: '513a9054-5897-11ee-8c99-0242ac120002')
+  end
+
+  it 'validates the home page' do
+    visit root_path
+    expect(page).to be_accessible
+  end
+
+  it 'validates the summaries page' do
+    visit summaries_path
+    expect(page).to be_accessible
+  end
+
+  it 'validates the checkout page' do
+    visit checkouts_path
+    expect(page).to be_accessible
+  end
+
+  it 'validates the requests page' do
+    visit requests_path
+    expect(page).to be_accessible
+  end
+
+  it 'validates the fines page' do
+    visit fines_path
+    expect(page).to be_accessible
+  end
+
+  it 'validates the payments page' do
+    visit payments_path
+    expect(page).to be_accessible
+  end
+
+  it 'validates the contact forms page' do
+    visit contact_forms_path
+    expect(page).to be_accessible
+  end
+
+  it 'validates the feedback forms page' do
+    visit feedback_path
+    expect(page).to be_accessible
+  end
+
+  it 'validates the login page' do
+    visit login_path
+    expect(page).to be_accessible
+  end
+
+  it 'validates the logout page' do
+    visit logout_path
+    expect(page).to be_accessible
+  end
+
+  it 'validates the reset_pin page' do
+    visit reset_pin_path
+    expect(page).to be_accessible
+  end
+
+  it 'validates the change_pin page' do
+    visit change_pin_path
+    expect(page).to be_accessible
+  end
+
+  it 'validates the unavaliable page' do
+    visit unavailable_path
+    expect(page).to be_accessible
+  end
+
+  def be_accessible
+    be_axe_clean.excluding('#g-recaptcha-response')
+  end
+end

--- a/spec/features/contact_form_spec.rb
+++ b/spec/features/contact_form_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe 'Contact form' do
       before { visit contact_path }
 
       it 'is "Contact Circulation & Privileges"' do
-        expect(page).to have_css('h2', text: 'Contact Circulation & Privileges')
+        expect(page).to have_css('h1', text: 'Contact Circulation & Privileges')
       end
     end
 
@@ -108,7 +108,7 @@ RSpec.describe 'Contact form' do
       before { visit contact_path(library: 'LATHROP') }
 
       it 'is "Contact Library"' do
-        expect(page).to have_css('h2', text: 'Contact library')
+        expect(page).to have_css('h1', text: 'Contact library')
       end
     end
   end


### PR DESCRIPTION
cloeses #951 

Updates in this PR, screenshots attached:
- pages without h1 had h1 elements added. Some h2 elements got migrated to h1
- links that were part of text elements got underlines added
- fix alert-info link text color to match alert info
- move global footer into footer (this should not change anything outside structure)
- remove roles contentinfo and form
- add axe spec

Homepage
![homepage](https://github.com/sul-dlss/mylibrary/assets/19173991/5cf76537-c8c7-4e22-af3c-6e300b82062c)

Summaries
![Summary](https://github.com/sul-dlss/mylibrary/assets/19173991/4e194652-84cc-4655-8ab2-1d4a0eb7f761)

Checkout
![Checkouts](https://github.com/sul-dlss/mylibrary/assets/19173991/837d3d65-63fa-4a2d-b265-03c6ee4afa0a)

Requests
![Requests](https://github.com/sul-dlss/mylibrary/assets/19173991/b5ad7bd4-bf7e-42e6-a162-1862806ee89b)

Fines
![Fines](https://github.com/sul-dlss/mylibrary/assets/19173991/5fe84a43-e2ac-407d-9c30-f9644bb36787)

Payments
![History](https://github.com/sul-dlss/mylibrary/assets/19173991/9da97341-749e-4841-960c-ef9763d60eac)

Contact
![Contact Circulation   Privileges](https://github.com/sul-dlss/mylibrary/assets/19173991/8d1777fe-290e-48ce-961c-91cecf0230c8)

Feedback
![Provide feedback](https://github.com/sul-dlss/mylibrary/assets/19173991/800499ad-eeee-40fd-a63c-92cc7f042e28)

Reset pin
![Screenshot 2024-03-12 at 2 56 01 PM](https://github.com/sul-dlss/mylibrary/assets/19173991/e683c955-a057-434b-835a-9279f5a643ff)

 Change pin
![Proxy, fee, or courtesy accounts](https://github.com/sul-dlss/mylibrary/assets/19173991/ea0accc8-a8d2-4ea4-a10f-0b9a595e42e0)

Unavailable
![Temporarily unavailable](https://github.com/sul-dlss/mylibrary/assets/19173991/01e58efb-e6f8-4a93-94e9-906795e657cb)
