### PR TITLE
Remove nav-link border styling

### DIFF
--- a/app/assets/stylesheets/base.scss
+++ b/app/assets/stylesheets/base.scss
@@ -29,8 +29,7 @@ a:focus,
 a:active {
   @include link-styling;
 
-  &.btn-link,
-  &.nav-link {
+  &.btn-link {
     border-bottom: 1px solid transparent;
   }
 }


### PR DESCRIPTION
This is causing the rest of the page to shift down 1px when hovering over the nav bar links. Presumably this was addressed upstream in bootstrap at some point and this work-around is no longer necessary.