### PR TITLE
Remove item_details argument; this was used in Symphony to limit the …

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -45,7 +45,7 @@ class ApplicationController < ActionController::Base
   end
 
   def patron_info_response
-    ils_client.patron_info(current_user.patron_key, item_details:)
+    ils_client.patron_info(current_user.patron_key)
   end
 
   def ils_client
@@ -58,10 +58,6 @@ class ApplicationController < ActionController::Base
 
   def logout_user!
     redirect_to logout_path if current_user?
-  end
-
-  def item_details
-    {}
   end
 
   def set_internal_pages_flash_message

--- a/app/controllers/checkouts_controller.rb
+++ b/app/controllers/checkouts_controller.rb
@@ -12,10 +12,4 @@ class CheckoutsController < ApplicationController
     @checkouts = patron_or_group.checkouts.sort_by { |x| x.sort_key(:due_date) }
     @requests = patron_or_group.requests.sort_by { |request| request.sort_key(:date) }
   end
-
-  private
-
-  def item_details
-    { circRecordList: true, holdRecordList: true }
-  end
 end

--- a/app/controllers/fines_controller.rb
+++ b/app/controllers/fines_controller.rb
@@ -22,8 +22,4 @@ class FinesController < ApplicationController
   def checkouts
     patron_or_group.checkouts.sort_by { |c| c.sort_key(:due_date) }
   end
-
-  def item_details
-    { blockList: true }
-  end
 end

--- a/app/controllers/renewals_controller.rb
+++ b/app/controllers/renewals_controller.rb
@@ -39,10 +39,6 @@ class RenewalsController < ApplicationController
 
   private
 
-  def item_details
-    { circRecordList: true }
-  end
-
   def bulk_renewal_success_flash(response)
     return unless response[:success].any?
 

--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -96,10 +96,6 @@ class RequestsController < ApplicationController
     params.require(%I[id not_needed_after])
   end
 
-  def item_details
-    { holdRecordList: true }
-  end
-
   def authorize_update!
     return if patron_or_group.requests.any? { |request| request.key == params[:id] }
 

--- a/app/services/folio_client.rb
+++ b/app/services/folio_client.rb
@@ -57,21 +57,17 @@ class FolioClient
     get_json("/users/#{CGI.escape(user_id)}")
   end
 
-  # rubocop:disable Lint/UnusedMethodArgument
   # FOLIO graphql call, compare to #patron_account
-  def patron_info(patron_key, item_details: {})
-    folio_graphql_client.patron_info(patron_key)
-  end
+  delegate :patron_info, to: :folio_graphql_client
 
   # FOLIO API call
-  def patron_account(patron_key, item_details: {})
+  def patron_account(patron_key)
     get_json("/patron/account/#{CGI.escape(patron_key)}", params: {
       includeLoans: true,
       includeCharges: true,
       includeHolds: true
     })
   end
-  # rubocop:enable Lint/UnusedMethodArgument
 
   def ping
     session_token.present?

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -63,21 +63,6 @@ RSpec.describe ApplicationController do
       end
     end
 
-    context 'with some needed item details' do
-      before do
-        allow(mock_client).to receive(:patron_info)
-        warden.set_user(user)
-      end
-
-      it 'passes through the details' do
-        allow(controller).to receive(:item_details).and_return(some: :value)
-
-        controller.patron
-        expect(mock_client).to have_received(:patron_info).with('513a9054-5897-11ee-8c99-0242ac120002',
-                                                                item_details: { some: :value })
-      end
-    end
-
     context 'without a logged in user' do
       it 'is a new instance of the Patron class' do
         expect(controller.patron).to be_nil


### PR DESCRIPTION
…types of information we returned, but with FOLIO we seemingly don't care about it anymore