### PR TITLE
Target .btn that are not .btn-link when setting background-color for disabled buttons

### DIFF
--- a/app/assets/stylesheets/base.scss
+++ b/app/assets/stylesheets/base.scss
@@ -19,13 +19,20 @@ a[target="_blank"], p a, form a{
   border-bottom: 1px solid $bright-blue;
 }
 
-:disabled {
-  // scss-lint:disable ImportantRule
-  background-color: $sul-btn-disabled-color !important;
+.btn:not(.btn-link):disabled {
+  background-color: $sul-btn-disabled-color;
   color: $white;
   cursor: not-allowed;
   text-decoration: none;
-  // scss-lint:enable ImportantRule
+}
+
+.btn-link:disabled {
+  color: $sul-btn-link-disabled-color;
+  opacity: 1;
+
+  svg {
+    fill: $sul-btn-link-disabled-color;
+  }
 }
 
 a:hover,

--- a/app/assets/stylesheets/sul-variables.scss
+++ b/app/assets/stylesheets/sul-variables.scss
@@ -35,6 +35,7 @@ $sul-btn-default-color: $cloud;
 $sul-btn-disabled-color: $cool-grey;
 $sul-btn-primary-color: $cardinal-red;
 $sul-btn-success-color: $bright-blue;
+$sul-btn-link-disabled-color: $blackish;
 $sul-footer-bg-color: $light-sandstone;
 $sul-h1-font-color: $blackish;
 $sul-h2-font-color: $stone;


### PR DESCRIPTION
Fixes a bug that I think was introduced here: https://github.com/sul-dlss/mylibrary/pull/385

I noticed that when clicking the .btn-link to renew an individual item the disabled state rendered the text unreadable because of the background color:

<img width="235" alt="Screenshot 2024-06-14 at 3 15 35 PM" src="https://github.com/sul-dlss/mylibrary/assets/458247/d09da0c9-9a9b-4066-a1b9-e48163740c5a">

The existing CSS rule to set styles for elements in the disabled state was too broad. I've adjusted the CSS so it targets only `.btn` elements that are not also `.btn-link`.

The renew link now looks like this (just like the surrounding plain text) when disabled:
<img width="189" alt="Screenshot 2024-06-14 at 5 46 16 PM" src="https://github.com/sul-dlss/mylibrary/assets/458247/7a531188-bb12-4635-9256-d70932347433">


And the renew all button still looks like this when disabled:
<img width="186" alt="Screenshot 2024-06-14 at 4 58 39 PM" src="https://github.com/sul-dlss/mylibrary/assets/458247/8ac41895-6b77-4c0f-be6f-ee34a0247d07">


