### PR TITLE
Set a data-turbo-submits-with message when renewing

### DIFF
--- a/app/views/checkouts/_checkout.html.erb
+++ b/app/views/checkouts/_checkout.html.erb
@@ -34,7 +34,9 @@
             <%= hidden_field_tag :item_id, checkout.item_id %>
             <%= hidden_field_tag :title, checkout.title %>
             <%= hidden_field_tag :group, params[:group] if params[:group] %>
-            <%= button_tag class: 'btn btn-link btn-renewable-submit btn-icon-prefix', type: 'submit' do %>
+            <%= button_tag class: 'btn btn-link btn-renewable-submit btn-icon-prefix',
+                           data: { turbo_submits_with: t('mylibrary.renew_item.in_progress_html') },
+                           type: 'submit' do %>
               <%= sul_icon 'renew' %> Renew this item
             <% end %>
           <% end %>

--- a/app/views/checkouts/_renew_all_button.html.erb
+++ b/app/views/checkouts/_renew_all_button.html.erb
@@ -1,8 +1,14 @@
 <% if patron_or_group.checkouts.any?(&:renewable?) %>
   <% if patron_or_group.can_renew? %>
-    <%= link_to all_eligible_renewals_path(group: params[:group]), class: 'btn btn-info mb-1', method: :post do %>
-      <%= sul_icon :'renew' %> Renew <%= pluralize(patron_or_group.checkouts.count(&:renewable?), 'eligible item') %>
-    <% end %>
+      <% renewable_count = patron_or_group.checkouts.count(&:renewable?) %>
+      <%= form_tag all_eligible_renewals_path, method: :post do %>
+        <%= hidden_field_tag :group, params[:group] if params[:group] %>
+        <%= button_tag class: 'btn btn-info mb-1',
+                        data: { turbo_submits_with: t('mylibrary.renew_all_items.in_progress_html', count: renewable_count) },
+                        type: 'submit' do %>
+          <%= sul_icon :'renew' %> Renew <%= pluralize(renewable_count, 'eligible item') %>
+        <% end %>
+      <% end %>
   <% else %>
     <button disabled class="btn btn-info mb-1"><%= sul_icon :'renew' %> Renewals blocked</button>
   <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -42,10 +42,14 @@ en:
       label: 'Library ID'
       help_text: 'Last 10 digits above the barcode on your library card'
     renew_item:
+      in_progress_html: <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span> Renewing this item
       success_html: <span class="font-weight-bold">Success!</span> "%{title}" was renewed.
       error_html: <span class="font-weight-bold">Sorry!</span> Something went wrong and "%{title}" was not renewed.
       deny_access: An unexpected error has occurred
     renew_all_items:
+      in_progress_html:
+        one: <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span> Renewing 1 item 
+        other: <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span> Renewing all %{count} eligible items
       success_html:
         one: <span class="font-weight-bold">Success!</span> 1 item was renewed.
         other: <span class="font-weight-bold">Success!</span> %{count} items were renewed.

--- a/spec/views/checkouts/_renew_all_button.html.erb_spec.rb
+++ b/spec/views/checkouts/_renew_all_button.html.erb_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe 'checkouts/_renew_all_button' do
   it 'renders a button' do
     render
 
-    expect(output).to have_link 'Renew 1 eligible item'
+    expect(output).to have_button 'Renew 1 eligible item'
   end
 
   context 'when the patron is e.g. blocked and unable to renew material' do


### PR DESCRIPTION
Part of #1083 -- prevents duplicate POST requests when renewing items takes a long time.

This takes advantage of turbo to display a "Renewing..." message after either the all or single renewal buttons is clicked. The renew all link is changed to a form so this will work.

Renew button before submitting:
<img width="232" alt="Screenshot 2024-06-17 at 3 04 31 PM" src="https://github.com/sul-dlss/mylibrary/assets/458247/4b40d85c-e733-45ed-86bd-7fbb89aced7d">

Renew button after submitting:
<img width="271" alt="Screenshot 2024-06-17 at 3 04 36 PM" src="https://github.com/sul-dlss/mylibrary/assets/458247/40f47c92-7e24-4c3d-8e73-50016e0085ad">
