### PR TITLE
Set bundle path

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -21,7 +21,9 @@ jobs:
     - name: Configure bundler
       run: bundle config set --local without 'production symphony'
     - name: Install ruby dependencies
-      run: bundle install
+      run: |
+        bundle config path vendor/bundle
+        bundle install
     - name: Install javascript dependencies
       run: yarn install
     - name: Run tests


### PR DESCRIPTION
This might fix the test environment setup failure here: https://github.com/sul-dlss/mylibrary/pull/1146

```
 The installation path is insecure. Bundler cannot continue.
/opt/hostedtoolcache/Ruby/3.2.4/x64/lib/ruby/gems/3.2.0/gems is world-writable
(without sticky bit).
Bundler cannot safely replace gems in world-writeable directories due to
potential vulnerabilities.
Please change the permissions of this directory or choose a different install
path.
Error: Process completed with exit code 38.
```