### PR TITLE
Include the new logo and change the color of the footer banner logo portion to a darker color

### DIFF
--- a/app/assets/stylesheets/application.sass.scss
+++ b/app/assets/stylesheets/application.sass.scss
@@ -19,3 +19,4 @@
 @import 'modules/requests';
 @import 'modules/skip_link';
 @import 'modules/nav_spinner';
+@import 'component-library-overrides';

--- a/app/assets/stylesheets/component-library-overrides.css
+++ b/app/assets/stylesheets/component-library-overrides.css
@@ -1,0 +1,39 @@
+/* These are styles mostly copied from the component library. They should be removed after moving to the component library */
+.navbar-logo,
+.prefooter-logo {
+  mask-image: url("https://cdn.jsdelivr.net/gh/sul-dlss/component-library@v2025-02-20/styles/StanfordLibraries-logo.svg");
+  mask-repeat: no-repeat;
+  mask-position: 0 center;
+  overflow: hidden;
+  text-indent: 100%;
+  white-space: nowrap;
+  width: 250px;
+
+  &.polychrome {
+    background-color: transparent;
+    mask-image: none;
+    background-image: url("https://cdn.jsdelivr.net/gh/sul-dlss/component-library@v2025-02-20/styles/StanfordLibraries-logo-poly.svg");
+    background-repeat: no-repeat;
+    background-position: 0 center;
+  }
+}
+
+.prefooter-logo {
+  background-color: white;
+}
+
+@media (width < 768px) {
+  .prefooter-logo {
+    min-height: 30px;
+  }
+}
+
+#sul-footer-links a {
+  color: white;
+  &:hover,
+  &:focus,
+  &:active {
+    border-bottom: none;
+    text-decoration: underline;
+  }
+}

--- a/app/assets/stylesheets/modules/navigation.scss
+++ b/app/assets/stylesheets/modules/navigation.scss
@@ -57,11 +57,11 @@
 }
 
 .navbar-logo {
-  background-color: white;
+  background-color: $cardinal-red;
 }
 
 .prefooter-logo {
-  background-color:  white;
+  background-color: white;
   width: 280px;
 }
 

--- a/app/assets/stylesheets/modules/navigation.scss
+++ b/app/assets/stylesheets/modules/navigation.scss
@@ -43,33 +43,3 @@
     font-size: $h3-font-size;
   }
 }
-
-// Adds the new library logo to the header & footer
-// until we can update MyLibrary to use the component library
-
-.navbar-logo, .prefooter-logo {
-  mask-image: url("https://cdn.jsdelivr.net/gh/sul-dlss/component-library@v2025-01-10/styles/StanfordLibraries-logo.svg");
-  mask-repeat: no-repeat;
-  mask-position: 0 center;
-  overflow: hidden;
-  text-indent: 100%;
-  white-space: nowrap;
-}
-
-.navbar-logo {
-  background-color: $cardinal-red;
-}
-
-.prefooter-logo {
-  background-color: white;
-  width: 280px;
-}
-
-#sul-footer-links ul li a {
-  color: white;
-}
-
-.sul-footer-align {
-  display: table-cell;
-  vertical-align: middle;
-}

--- a/app/assets/stylesheets/modules/navigation.scss
+++ b/app/assets/stylesheets/modules/navigation.scss
@@ -43,3 +43,33 @@
     font-size: $h3-font-size;
   }
 }
+
+// Adds the new library logo to the header & footer
+// until we can update MyLibrary to use the component library
+
+.navbar-logo, .prefooter-logo {
+  mask-image: url("https://cdn.jsdelivr.net/gh/sul-dlss/component-library@v2025-01-10/styles/StanfordLibraries-logo.svg");
+  mask-repeat: no-repeat;
+  mask-position: 0 center;
+  overflow: hidden;
+  text-indent: 100%;
+  white-space: nowrap;
+}
+
+.navbar-logo {
+  background-color: white;
+}
+
+.prefooter-logo {
+  background-color:  white;
+  width: 280px;
+}
+
+#sul-footer-links ul li a {
+  color: white;
+}
+
+.sul-footer-align {
+  display: table-cell;
+  vertical-align: middle;
+}

--- a/app/assets/stylesheets/modules/sul-footer.scss
+++ b/app/assets/stylesheets/modules/sul-footer.scss
@@ -29,38 +29,3 @@ $sul-footer-height: 80px;
   position: relative;
 }
 
-#sul-footer {
-  display: table;
-  height: $sul-footer-height;
-  padding: 0;
-
-  ul {
-    list-style-type: none;
-    margin: 0;
-    padding: 0;
-
-    li {
-      display: inline;
-      margin: 0 13px 3px 0;
-      padding: 0;
-
-      a {
-        white-space: nowrap;
-      }
-    }
-  }
-
-  #sul-footer-img {
-    display: table-cell;
-    vertical-align: middle;
-    width: 162px;
-  }
-
-  #sul-footer-links {
-    display: table-cell;
-    font-size: small;
-    padding-left: 15px;
-    text-align: left;
-    vertical-align: middle;
-  }
-}

--- a/app/assets/stylesheets/modules/top_navbar.scss
+++ b/app/assets/stylesheets/modules/top_navbar.scss
@@ -10,7 +10,7 @@
   }
 
   .nav-link {
-    color: white;
+    color: $cardinal-red;
     border-bottom: 3px solid transparent;
     padding-bottom: 0;
     padding-left: 0;

--- a/app/assets/stylesheets/modules/top_navbar.scss
+++ b/app/assets/stylesheets/modules/top_navbar.scss
@@ -10,7 +10,7 @@
   }
 
   .nav-link {
-    color: $cardinal-red;
+    color: white;
     border-bottom: 3px solid transparent;
     padding-bottom: 0;
     padding-left: 0;
@@ -22,7 +22,7 @@
     &:hover,
     &:focus,
     &:active {
-      border-bottom: 3px solid $cardinal-red;
+      border-bottom: 3px solid white;
     }
   }
 }

--- a/app/assets/stylesheets/su-identity-overrides.scss
+++ b/app/assets/stylesheets/su-identity-overrides.scss
@@ -4,3 +4,23 @@
 #global-footer .container { // bootstrap container styles conflict w/ su-identity
   width: auto;
 }
+
+
+// These global-footer styles are temporary, until we switch to the component library.
+#global-footer {
+  margin-top: -220px;
+}
+
+@media screen and (min-width: 768px) {
+  #global-footer {
+    margin-top: -124px;
+    height: 150px;
+  }
+}
+
+@media screen and (min-width: 992px) {
+  #global-footer {
+    margin-top: -164px;
+    height: 164px;
+  }
+}

--- a/app/assets/stylesheets/sul-variables.scss
+++ b/app/assets/stylesheets/sul-variables.scss
@@ -14,6 +14,7 @@ $stone: #544948;
 $very-pale-orange: #ffe9c5;
 $very-pale-red: #ffe5ea;
 $white: #fff;
+$stanford-black: #2e2d29;
 
 //Stanford University Web Interactive Colors
 $su-digital-red: #b1040e;
@@ -33,7 +34,7 @@ $sul-btn-disabled-color: $cool-grey;
 $sul-btn-primary-color: $cardinal-red;
 $sul-btn-success-color: $su-digital-blue;
 $sul-btn-link-disabled-color: $blackish;
-$sul-footer-bg-color: $light-sandstone;
+$sul-footer-bg-color: $stanford-black;
 $sul-h1-font-color: $blackish;
 $sul-h2-font-color: $stone;
 $sul-h3-font-color: $cool-grey;

--- a/app/views/shared/_sul_footer.html.erb
+++ b/app/views/shared/_sul_footer.html.erb
@@ -1,10 +1,10 @@
 <footer>
   <div id="sul-footer-container">
     <div id="sul-footer" class="container">
-      <div id="sul-footer-img" class="span2">
-        <%= link_to 'https://library.stanford.edu' do %>
-          <%= image_tag "sul-logo-stacked.svg", alt: "Stanford Libraries", height: 45 %>
-        <% end %>
+      <div class='sul-footer-align'>
+        <div id="sul-footer-img" class="d-flex w-auto">
+          <a href="https://library.stanford.edu" class="prefooter-logo">Stanford University Libraries</a>
+        </div>
       </div>
       <div id="sul-footer-links" class="span2">
         <ul>

--- a/app/views/shared/_sul_footer.html.erb
+++ b/app/views/shared/_sul_footer.html.erb
@@ -1,9 +1,9 @@
 <footer>
   <div id="sul-footer-container">
     <div id="sul-footer" class="container">
-      <div class='sul-footer-align'>
-        <div id="sul-footer-img" class="d-flex w-auto">
-          <a href="https://library.stanford.edu" class="prefooter-logo">Stanford University Libraries</a>
+      <div id="sul-footer-img" class="span2">
+        <div class="d-flex">
+        <a href="https://library.stanford.edu" class="prefooter-logo">Stanford University Libraries</a>
         </div>
       </div>
       <div id="sul-footer-links" class="span2">

--- a/app/views/shared/_sul_footer.html.erb
+++ b/app/views/shared/_sul_footer.html.erb
@@ -1,18 +1,18 @@
 <footer>
   <div id="sul-footer-container">
-    <div id="sul-footer" class="container">
-      <div id="sul-footer-img" class="span2">
-        <div class="d-flex">
-        <a href="https://library.stanford.edu" class="prefooter-logo">Stanford University Libraries</a>
+    <div class="container pt-3">
+      <div class="row">
+        <div id="sul-footer-img" class="col-sm-12 col-lg-4 col-xl-3 d-flex justify-content-center justify-content-lg-start mb-3 mb-lg-0">
+          <a href="https://library.stanford.edu" class="prefooter-logo">Stanford University Libraries</a>
         </div>
-      </div>
-      <div id="sul-footer-links" class="span2">
-        <ul>
-          <li><a href="https://library-hours.stanford.edu/">Hours &amp; locations</a></li>
-          <li><a href="https://mylibrary.stanford.edu/">My Account</a></li>
-          <li><a href="https://library.stanford.edu/contact-us">Ask us</a></li>
-          <li><a href="https://library-status.stanford.edu/">System status</a></li>
-        </ul>
+        <div id="sul-footer-links" class="col d-flex justify-content-center justify-content-lg-start align-items-center">
+          <ul class="list-unstyled d-flex text-center my-0">
+            <li class="mr-3"><a href="https://library-hours.stanford.edu/">Hours &amp; locations</a></li>
+            <li class="mr-3"><a href="https://mylibrary.stanford.edu/">My Account</a></li>
+            <li class="mr-3"><a href="https://library.stanford.edu/contact-us">Ask us</a></li>
+            <li class="mr-3"><a href="https://library-status.stanford.edu/">System status</a></li>
+          </ul>
+        </div>
       </div>
     </div>
   </div>

--- a/app/views/shared/_top_navbar.html.erb
+++ b/app/views/shared/_top_navbar.html.erb
@@ -1,9 +1,9 @@
-<nav id="topnav" class="navbar navbar-expand-always" role="navigation">
+<nav id="topnav" class="navbar navbar-expand-always bg-cardinal-red" role="navigation">
   <div class="container">
-    <%= link_to 'https://library.stanford.edu', class: 'navbar-brand' do %>
-      <%= image_tag "sul-logo.svg", class: "su-logo d-none d-sm-block", alt: "Stanford Libraries", height: 25 %>
-      <%= image_tag "sul-logo-stacked.svg", class: "su-logo d-sm-none d-md-none d-lg-none d-xl-none", alt: "Stanford Libraries", height: 25 %>
-    <% end %>
+    <a class="mb-0 navbar-brand navbar-logo" 
+      href="https://library.stanford.edu"
+      >Stanford University Libraries
+    </a>
 
     <ul class="navbar-nav ml-auto">
       <li class="nav-item">

--- a/app/views/shared/_top_navbar.html.erb
+++ b/app/views/shared/_top_navbar.html.erb
@@ -1,4 +1,4 @@
-<nav id="topnav" class="navbar navbar-expand-always bg-cardinal-red" role="navigation">
+<nav id="topnav" class="navbar navbar-expand-always" role="navigation">
   <div class="container">
     <a class="mb-0 navbar-brand navbar-logo" 
       href="https://library.stanford.edu"

--- a/app/views/shared/_top_navbar.html.erb
+++ b/app/views/shared/_top_navbar.html.erb
@@ -1,6 +1,6 @@
 <nav id="topnav" class="navbar navbar-expand-always" role="navigation">
   <div class="container">
-    <a class="mb-0 navbar-brand navbar-logo" 
+    <a class="mb-0 navbar-brand navbar-logo polychrome"
       href="https://library.stanford.edu"
       >Stanford University Libraries
     </a>


### PR DESCRIPTION
Background: 
We need to move the MyLibrary logo to the new Stanford Libraries logo.  The objective is NOT to redo the header and footer in their entirety, as the next SearchWorks related workcycle may look into redoing the header/footer in its entirety.

I based this work on the component library and looking at changes in this VT Arclight PR: https://github.com/sul-dlss/vt-arclight/commit/79cd4960ed02d0413ecb34332cbde2c5feff7d57, 

What this pull request does:
- Uses the new logo and related classes for the header
- Changes the footer portion to correspond to a darker shade. This was a request based on the look and feel for the footer in https://library.stanford.edu/all . 
- Use the new logo in the footer. 
- Changes the links in that footer section to be white.

**Before Header**
![Screenshot 2025-01-29 at 4 38 54 PM](https://github.com/user-attachments/assets/03b31536-e47e-4bd3-8593-b8ce59fc94c9)


**After Header**
![Screenshot 2025-01-29 at 4 39 29 PM](https://github.com/user-attachments/assets/9c73fb1a-08d5-49e6-9f76-db713a6e1909)


**Before Footer**
![Screenshot 2025-01-29 at 4 39 52 PM](https://github.com/user-attachments/assets/19159759-8e38-435c-bcc0-c11465b2fa5d)


**After Footer**
![Screenshot 2025-01-29 at 4 40 09 PM](https://github.com/user-attachments/assets/10bbe473-c881-42b3-bf75-6755cccbfcfe)

