### PR TITLE
Remove jquery-rails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,8 +40,6 @@ gem 'faraday-retry'
 
 gem 'okcomputer'
 
-gem 'jquery-rails'
-
 gem 'warden'
 
 gem 'nokogiri'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -212,10 +212,6 @@ GEM
     jbuilder (2.13.0)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
-    jquery-rails (4.6.0)
-      rails-dom-testing (>= 1, < 3)
-      railties (>= 4.2.0)
-      thor (>= 0.14, < 2.0)
     jsbundling-rails (1.3.1)
       railties (>= 6.0.0)
     json (2.10.1)
@@ -497,7 +493,6 @@ DEPENDENCIES
   global_alerts
   honeybadger
   jbuilder (~> 2.7)
-  jquery-rails
   jsbundling-rails (~> 1.3)
   listen (~> 3.3)
   mysql2


### PR DESCRIPTION
We're getting jquery from yarn/jsbundling-rails