### PR TITLE
Rescue BorrowDirectError in BorrowDirectReshareClient ping check

### DIFF
--- a/app/services/borrow_direct_reshare_client.rb
+++ b/app/services/borrow_direct_reshare_client.rb
@@ -41,7 +41,7 @@ class BorrowDirectReshareClient
 
   def ping
     session_token.present?
-  rescue HTTP::Error
+  rescue HTTP::Error, BorrowDirectError
     false
   end
 


### PR DESCRIPTION
This should prevent ops from getting alerted that there's a problem with mylibrary if borrowdirect happens to be down, which is an optional okcomputer check.

See https://app.honeybadger.io/projects/62116/faults/117670965