### PR TITLE
Don't show patrons places they can't pick up items because of their patron group.

### DIFF
--- a/app/helpers/requests_helper.rb
+++ b/app/helpers/requests_helper.rb
@@ -30,7 +30,7 @@ module RequestsHelper
   # @return [Array<Array<String, String>>] An array of service point options in [label, value] format
   def restricted_service_point_options(request, patron)
     request.restricted_pickup_service_points.filter_map do |service_point|
-      if service_point.patron_ineligible_for_pickup?(patron) &&
+      if service_point.patron_unpermitted_for_pickup?(patron) &&
          service_point.id != request.service_point_id # if the service point is already selected, don't take it away
         next
       end
@@ -53,7 +53,7 @@ module RequestsHelper
     # Map the service points to the [label, value] format for options_for_select
     default_service_points.compact.uniq(&:id).select { |service_point| service_point.pickup_location == true }
                           .filter_map do |service_point|
-                            if service_point.patron_ineligible_for_pickup?(patron) &&
+                            if service_point.patron_unpermitted_for_pickup?(patron) &&
                                # ... but if the service point is already selected, don't take it away
                                service_point.id != request.service_point_id
                               next

--- a/app/helpers/requests_helper.rb
+++ b/app/helpers/requests_helper.rb
@@ -4,9 +4,9 @@
 module RequestsHelper
   ##
   # Generates the options needed to change a request's location
-  def request_location_options(request)
+  def request_location_options(request, patron)
     options_for_select(
-      service_points(request),
+      service_points(request, patron),
       # the second param here pre-selects the current service point in the dropdown
       selected: request.service_point_id
     )
@@ -16,10 +16,10 @@ module RequestsHelper
   #
   # @param request [Request] The request object
   # @return [Array<Array<String, String>>] Array of service points in [label, value] format for options_for_select
-  def service_points(request)
-    return restricted_service_point_options(request) if request.restricted_pickup_service_points.present?
+  def service_points(request, patron)
+    return restricted_service_point_options(request, patron) if request.restricted_pickup_service_points.present?
 
-    service_point_options(request)
+    service_point_options(request, patron)
   end
 
   private
@@ -28,9 +28,11 @@ module RequestsHelper
   #
   # @param request [Request] The request object
   # @return [Array<Array<String, String>>] An array of service point options in [label, value] format
-  def restricted_service_point_options(request)
-    request.restricted_pickup_service_points.map do |item|
-      [item['discoveryDisplayName'], item['id']]
+  def restricted_service_point_options(request, patron)
+    request.restricted_pickup_service_points.filter_map do |service_point|
+      next if patron && (Settings.service_points[service_point['code']]&.cant_pick_up || [])&.include?(patron.patron_group_name) && service_point['id'] != request.service_point_id
+
+      [service_point['discoveryDisplayName'], service_point['id']]
     end
   end
 
@@ -38,7 +40,7 @@ module RequestsHelper
   #
   # @param request [Request] The request object
   # @return [Array<Array<String, String>>] An array of service point options in [label, value] format
-  def service_point_options(request)
+  def service_point_options(request, patron)
     # start with the full list of defaults
     default_service_points = Folio::ServicePoint.default_service_points
     # Add the request's origin service point to the list
@@ -47,6 +49,9 @@ module RequestsHelper
     # Filter out non-pickup locations
     # Map the service points to the [label, value] format for options_for_select
     default_service_points.compact.uniq(&:id).select { |item| item.pickup_location == true }
-                          .map { |item| [item.name, item.id] }
+                          .filter_map do |service_point|
+                            next if patron && service_point.ineligible_patron_groups.include?(patron.patron_group_name) && service_point.id != request.service_point_id
+                            [service_point.name, service_point.id]
+                          end
   end
 end

--- a/app/models/folio/group.rb
+++ b/app/models/folio/group.rb
@@ -18,9 +18,7 @@ module Folio
                    end
     end
 
-    delegate :barred?, to: :sponsor
-
-    delegate :blocked?, to: :sponsor
+    delegate :barred?, :blocked?, :patron_group_name, to: :sponsor
 
     def status
       standing

--- a/app/models/folio/patron.rb
+++ b/app/models/folio/patron.rb
@@ -102,6 +102,10 @@ module Folio
       "#{first_name} #{last_name}"
     end
 
+    def patron_group_name
+      user_info.dig('patronGroup', 'desc')
+    end
+
     def borrow_limit
       borrow_limit = user_info.dig('patronGroup', 'limits')&.find do |limit|
         limit.dig('condition', 'name') == 'Maximum number of items charged out'

--- a/app/models/folio/request.rb
+++ b/app/models/folio/request.rb
@@ -72,7 +72,7 @@ module Folio
     end
 
     def item_call_key
-      record.dig('item', 'item', 'effectiveCallNumberComponents', 'callNumber')
+      item&.dig('effectiveCallNumberComponents', 'callNumber')
     end
 
     def service_point_name
@@ -88,7 +88,11 @@ module Folio
     end
 
     def restricted_pickup_service_points
-      record.dig('item', 'item', 'effectiveLocation', 'details', 'pageServicePoints')
+      service_points = item&.dig('effectiveLocation', 'details', 'pageServicePoints') || []
+
+      @restricted_pickup_service_points ||= service_points.map do |service_point|
+        Folio::ServicePoint.from_dynamic(service_point)
+      end
     end
 
     # rubocop:disable Metrics/MethodLength
@@ -118,5 +122,9 @@ module Folio
     end
 
     def manage_request_link; end
+
+    def item
+      record.dig('item', 'item')
+    end
   end
 end

--- a/app/models/folio/service_point.rb
+++ b/app/models/folio/service_point.rb
@@ -5,7 +5,7 @@ module Folio
     attr_reader :id, :code, :name, :pickup_location, :is_default_pickup, :is_default_for_campus
 
     # rubocop:disable Metrics/ParameterLists
-    def initialize(id:, code:, name:, pickup_location:, is_default_pickup:, is_default_for_campus:)
+    def initialize(id:, code:, name:, pickup_location:, is_default_pickup: false, is_default_for_campus: false)
       @id = id
       @code = code
       @name = name
@@ -17,6 +17,12 @@ module Folio
 
     def ineligible_patron_groups
       Settings.service_points[code]&.cant_pick_up || []
+    end
+
+    def patron_ineligible_for_pickup?(patron = nil)
+      return false unless patron
+
+      ineligible_patron_groups.include?(patron.patron_group_name)
     end
 
     class << self

--- a/app/models/folio/service_point.rb
+++ b/app/models/folio/service_point.rb
@@ -15,6 +15,10 @@ module Folio
     end
     # rubocop:enable Metrics/ParameterLists
 
+    def ineligible_patron_groups
+      Settings.service_points[code]&.cant_pick_up || []
+    end
+
     class << self
       def all
         @all ||= Folio::Types.get_type('service_points').map { |json| from_dynamic(json) }

--- a/app/models/folio/service_point.rb
+++ b/app/models/folio/service_point.rb
@@ -15,14 +15,14 @@ module Folio
     end
     # rubocop:enable Metrics/ParameterLists
 
-    def ineligible_patron_groups
-      Settings.service_points[code]&.cant_pick_up || []
-    end
-
-    def patron_ineligible_for_pickup?(patron = nil)
+    def patron_unpermitted_for_pickup?(patron = nil)
       return false unless patron
 
-      ineligible_patron_groups.include?(patron.patron_group_name)
+      unpermitted_pickup_groups.include?(patron.patron_group_name)
+    end
+
+    def unpermitted_pickup_groups
+      Settings.service_points[code]&.unpermitted_pickup_groups || []
     end
 
     class << self

--- a/app/views/requests/edit.html.erb
+++ b/app/views/requests/edit.html.erb
@@ -10,7 +10,7 @@
     <%= hidden_field_tag :current_fill_by_date, @request&.fill_by_date&.strftime('%Y-%m-%d') %>
     <div class="form-group">
       <%= label_tag :service_point, 'Pickup point' %>
-      <%= select_tag :service_point, request_location_options(@request), class: 'form-control' %>
+      <%= select_tag :service_point, request_location_options(@request, patron_or_group), class: 'form-control' %>
     </div>
     <% if @request.fill_by_date %>
       <div class="form-group">

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -40,8 +40,8 @@ cybersource:
 
 service_points:
   LANE-DESK:
-    cant_pick_up: [bus-guest, law-alumni, law-guest, sul-contractprograms, sul-guest, sul-purchased, sul-short-term]
+    unpermitted_pickup_groups: [bus-guest, law-alumni, law-guest, sul-contractprograms, sul-guest, sul-purchased, sul-short-term]
   BUS-IDESK:
-    cant_pick_up: [lane-guest, law-alumni, law-guest, sul-guest, sul-purchased, sul-contractprograms, sul-short-term, visitor]
+    unpermitted_pickup_groups: [lane-guest, law-alumni, law-guest, sul-guest, sul-purchased, sul-contractprograms, sul-short-term, visitor]
   LAW:
-    cant_pick_up: [lane-guest, bus-guest, sul-guest, sul-contractprograms, sul-purchased, sul-short-term, visitor]
+    unpermitted_pickup_groups: [lane-guest, bus-guest, sul-guest, sul-contractprograms, sul-purchased, sul-short-term, visitor]

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -37,3 +37,11 @@ cybersource:
   access_key: 'change_me'
   secret_key: 'change_me'
   profile_id: 'change_me'
+
+service_points:
+  LANE-DESK:
+    cant_pick_up: [bus-guest, law-alumni, law-guest, sul-contractprograms, sul-guest, sul-purchased, sul-short-term]
+  BUS-IDESK:
+    cant_pick_up: [lane-guest, law-alumni, law-guest, sul-guest, sul-purchased, sul-contractprograms, sul-short-term, visitor]
+  LAW:
+    cant_pick_up: [lane-guest, bus-guest, sul-guest, sul-contractprograms, sul-purchased, sul-short-term, visitor]

--- a/spec/helpers/requests_helper_spec.rb
+++ b/spec/helpers/requests_helper_spec.rb
@@ -4,13 +4,7 @@ require 'rails_helper'
 
 RSpec.describe RequestsHelper do
   let(:default_service_points) do
-    build(:default_service_points)
-  end
-
-  before do
-    allow(Folio::ServicePoint).to receive_messages(
-      default_service_points:
-    )
+    Folio::ServicePoint.default_service_points
   end
 
   describe '#request_location_options' do
@@ -60,7 +54,7 @@ RSpec.describe RequestsHelper do
 
       it 'puts all the defaults into the options list' do
         options = helper.request_location_options(request)
-        expect(options).to have_css 'option', count: 2
+        expect(options).to have_css 'option', count: default_service_points.count
       end
 
       it 'pre-selects the origin service point of the request' do
@@ -90,7 +84,7 @@ RSpec.describe RequestsHelper do
 
       it 'adds the origin service point to the default options list if it is a pickup location' do
         options = helper.request_location_options(request)
-        expect(options).to have_css 'option', count: 3
+        expect(options).to have_css 'option', count: default_service_points.count + 1
       end
 
       it 'pre-selects the origin service point of the request' do
@@ -126,7 +120,7 @@ RSpec.describe RequestsHelper do
 
       it 'keeps the original default options list' do
         options = helper.request_location_options(request)
-        expect(options).to have_css 'option', count: 2
+        expect(options).to have_css 'option', count: default_service_points.count
       end
     end
   end

--- a/spec/helpers/requests_helper_spec.rb
+++ b/spec/helpers/requests_helper_spec.rb
@@ -139,9 +139,9 @@ RSpec.describe RequestsHelper do
                                       is_default_for_campus: nil,
                                       is_default_pickup: false,
                                       name: 'Archive of Recorded Sound',
-                                      ineligible_patron_groups: [],
+                                      unpermitted_pickup_groups: [],
                                       pickup_location: true,
-                                      patron_ineligible_for_pickup?: false)
+                                      patron_unpermitted_for_pickup?: false)
         )
         allow(request).to receive(:restricted_pickup_service_points).and_return(nil)
       end

--- a/spec/views/requests/edit.html.erb_spec.rb
+++ b/spec/views/requests/edit.html.erb_spec.rb
@@ -16,7 +16,13 @@ RSpec.describe 'requests/edit' do
     )
   end
 
+  let(:patron_or_group) { instance_double(Folio::Patron, patron_group_name: nil) }
+
   before do
+    without_partial_double_verification do
+      allow(view).to receive_messages(patron_or_group:)
+    end
+
     assign(:request, mock_request)
     render
   end


### PR DESCRIPTION
Fixes #1234 

We're not currently validating and enforcing the pickup service point (for this or location-restricted pages), but at least we won't show patrons service points that they shouldn't choose. 

If the patron already has an open request that's delivered to some restricted service point, it's probably because the patron talked to library staff and negotiated access (and library staff placed the request for them). In that case, we get to leave the service point (but we shouldn't offer it as an option otherwise..)