### PR TITLE
Pull over Folio::TypeStore from requests and use it for location data.

### DIFF
--- a/app/helpers/contact_forms_helper.rb
+++ b/app/helpers/contact_forms_helper.rb
@@ -4,7 +4,7 @@
 module ContactFormsHelper
   def contact_form_to(code = nil)
     label = ['Circulation & Privileges']
-    label[0] = Folio::Library.find_by_code(code)&.name if code
+    label[0] = Folio::Types.libraries.find_by(code: code)&.name if code
     label << ' ('
     label << link_to(library_email(code), "mailto:#{library_email(code)}")
     label << ')'

--- a/app/helpers/requests_helper.rb
+++ b/app/helpers/requests_helper.rb
@@ -47,7 +47,7 @@ module RequestsHelper
     # start with the full list of defaults
     default_service_points = Folio::ServicePoint.default_service_points
     # Add the request's origin service point to the list
-    default_service_points << Folio::ServicePoint.find_by_id(request.service_point_id)
+    default_service_points << Folio::Types.service_points.find_by(id: request.service_point_id)
     # Remove duplicates and nils in case origin was already in the default list or doesn't exit
     # Filter out non-pickup locations
     # Map the service points to the [label, value] format for options_for_select

--- a/app/models/folio/library.rb
+++ b/app/models/folio/library.rb
@@ -3,15 +3,15 @@
 module Folio
   Library = Data.define(:id, :name, :code) do
     def self.all
-      @all ||= Folio::Types.get_type('libraries').map { |json| from_dynamic(json) }
+      Folio::Types.libraries
     end
 
     def self.find_by_code(code)
-      all.find { |item| item.code == code }
+      Folio::Types.libraries.find_by(code: code)
     end
 
     def self.find_by_id(id)
-      all.find { |item| item.id == id }
+      Folio::Types.libraries.find_by(id: id)
     end
 
     def self.from_dynamic(json)

--- a/app/models/folio/library.rb
+++ b/app/models/folio/library.rb
@@ -2,18 +2,6 @@
 
 module Folio
   Library = Data.define(:id, :name, :code) do
-    def self.all
-      Folio::Types.libraries
-    end
-
-    def self.find_by_code(code)
-      Folio::Types.libraries.find_by(code: code)
-    end
-
-    def self.find_by_id(id)
-      Folio::Types.libraries.find_by(id: id)
-    end
-
     def self.from_dynamic(json)
       new(
         id: json.fetch('id'),

--- a/app/models/folio/location.rb
+++ b/app/models/folio/location.rb
@@ -3,22 +3,10 @@
 module Folio
   Location = Data.define(:id, :library, :library_id, :code, :discovery_display_name,
                          :name, :primary_service_point_id, :details) do
-    def self.all
-      Folio::Types.locations
-    end
-
-    def self.find_by_code(code)
-      Folio::Types.locations.find_by(code: code)
-    end
-
-    def self.find_by_id(id)
-      Folio::Types.locations.find_by(id: id)
-    end
-
     def self.from_dynamic(json)
       new(
         id: json.fetch('id'),
-        library: Folio::Library.find_by_id(json['libraryId'] || json.dig('library', 'id')),
+        library: Folio::Types.libraries.find_by(id: json['libraryId'] || json.dig('library', 'id')),
         library_id: json['libraryId'] || json.dig('library', 'id'),
         code: json.fetch('code'),
         discovery_display_name: json['discoveryDisplayName'] || json['name'] || json.fetch('id'),

--- a/app/models/folio/location.rb
+++ b/app/models/folio/location.rb
@@ -4,15 +4,15 @@ module Folio
   Location = Data.define(:id, :library, :library_id, :code, :discovery_display_name,
                          :name, :primary_service_point_id, :details) do
     def self.all
-      @all ||= Folio::Types.get_type('locations').map { |json| from_dynamic(json) }
+      Folio::Types.locations
     end
 
     def self.find_by_code(code)
-      all.find { |item| item.code == code }
+      Folio::Types.locations.find_by(code: code)
     end
 
     def self.find_by_id(id)
-      all.find { |item| item.id == id }
+      Folio::Types.locations.find_by(id: id)
     end
 
     def self.from_dynamic(json)

--- a/app/models/folio/record_location.rb
+++ b/app/models/folio/record_location.rb
@@ -28,11 +28,15 @@ module Folio
     end
 
     def effective_location
-      @effective_location ||= Folio::Location.find_by_code(effective_location_code)
+      return @effective_location if defined?(@effective_location)
+
+      @effective_location = Folio::Types.locations.find_by(code: effective_location_code)
     end
 
     def permanent_location
-      @permanent_location ||= Folio::Location.find_by_code(permanent_location_code)
+      return @permanent_location if defined?(@permanent_location)
+
+      @permanent_location = Folio::Types.locations.find_by(code: permanent_location_code)
     end
 
     private

--- a/app/models/folio/request.rb
+++ b/app/models/folio/request.rb
@@ -72,7 +72,7 @@ module Folio
     end
 
     def service_point_name
-      Folio::ServicePoint.find_by_id(service_point_id)&.name || service_point_code
+      Folio::Types.service_points.find_by(id: service_point_id)&.name || service_point_code
     end
 
     def service_point_code

--- a/app/models/folio/service_point.rb
+++ b/app/models/folio/service_point.rb
@@ -26,20 +26,12 @@ module Folio
     end
 
     class << self
-      def all
-        Folio::Types.service_points
-      end
-
       def default_service_points
-        Folio::Types.service_points.where(is_default_pickup: true)
+        Folio::Types.service_points.where(is_default_pickup: true).to_a
       end
 
       def name_by_code(code)
         Folio::Types.service_points.find_by(code: code)&.name
-      end
-
-      def find_by_id(id)
-        Folio::Types.service_points.find_by(id: id)
       end
 
       def from_dynamic(json)

--- a/app/models/folio/service_point.rb
+++ b/app/models/folio/service_point.rb
@@ -27,19 +27,19 @@ module Folio
 
     class << self
       def all
-        @all ||= Folio::Types.get_type('service_points').map { |json| from_dynamic(json) }
+        Folio::Types.service_points
       end
 
       def default_service_points
-        all.select { |item| item.is_default_pickup == true }
+        Folio::Types.service_points.where(is_default_pickup: true)
       end
 
       def name_by_code(code)
-        all.find { |item| item.code == code }&.name
+        Folio::Types.service_points.find_by(code: code)&.name
       end
 
       def find_by_id(id)
-        all.find { |item| item.id == id }
+        Folio::Types.service_points.find_by(id: id)
       end
 
       def from_dynamic(json)

--- a/app/models/illiad_requests.rb
+++ b/app/models/illiad_requests.rb
@@ -138,7 +138,7 @@ class IlliadRequests
     end
 
     def service_point_name
-      Folio::Library.find_by_code(library_code)&.name
+      Folio::Types.libraries.find_by(code: library_code)&.name
     end
 
     def waitlist_position; end

--- a/app/services/folio/type_store.rb
+++ b/app/services/folio/type_store.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module Folio
+  # An interface to type data
+  class TypeStore
+    attr_reader :klass, :data
+
+    include Enumerable
+
+    def initialize(klass, data_from_cache)
+      @klass = klass
+      @data = data_from_cache.map { |p| klass.from_dynamic(p) }.freeze
+    end
+
+    delegate :each, to: :data
+
+    def all
+      data
+    end
+
+    def find_by(**)
+      where(**).first
+    end
+
+    def where(**kwargs) # rubocop:disable Metrics/AbcSize
+      return to_enum(:where, **kwargs) unless block_given?
+
+      raise ArgumentError("expected a single argument, got #{kwargs.inspect}") unless kwargs.size == 1
+
+      key = kwargs.keys.first
+      raise ArgumentError("Unknown finder attribute #{key.inspect}") unless finder_attributes.include?(key)
+
+      each { |candidate| yield(candidate) if candidate.public_send(key) == kwargs[key] }
+    end
+
+    private
+
+    def finder_attributes
+      @finder_attributes ||= klass.instance_methods(false)
+    end
+  end
+end

--- a/app/services/folio/type_store.rb
+++ b/app/services/folio/type_store.rb
@@ -9,7 +9,7 @@ module Folio
 
     def initialize(klass, data_from_cache)
       @klass = klass
-      @data = data_from_cache.map { |p| klass.from_dynamic(p) }.freeze
+      @data = data_from_cache.map { |p| p.is_a?(Hash) ? klass.from_dynamic(p) : p }.freeze
     end
 
     delegate :each, to: :data

--- a/app/services/folio/types.rb
+++ b/app/services/folio/types.rb
@@ -3,7 +3,7 @@
 module Folio
   class Types
     class << self
-      delegate :loan_policies, :get_type, to: :instance
+      delegate :loan_policies, :get_type, :libraries, :locations, to: :instance
     end
 
     def self.instance
@@ -34,6 +34,18 @@ module Folio
 
       file = cache_dir.join("#{type}.json")
       JSON.parse(file.read) if file.exist?
+    end
+
+    def libraries
+      @libraries ||= TypeStore.new(Folio::Library, get_type('libraries'))
+    end
+
+    def locations
+      @locations ||= TypeStore.new(Folio::Location, get_type('locations'))
+    end
+
+    def service_points
+      @service_points ||= TypeStore.new(Folio::ServicePoint, get_type('service_points'))
     end
 
     private

--- a/app/services/folio/types.rb
+++ b/app/services/folio/types.rb
@@ -3,7 +3,7 @@
 module Folio
   class Types
     class << self
-      delegate :loan_policies, :get_type, :libraries, :locations, to: :instance
+      delegate :loan_policies, :get_type, :libraries, :locations, :service_points, to: :instance
     end
 
     def self.instance

--- a/spec/features/navigation_spec.rb
+++ b/spec/features/navigation_spec.rb
@@ -198,7 +198,7 @@ RSpec.describe 'Navigation' do
 
     before do
       allow(mock_client).to receive(:patron_info).with('ec52d62d-9f0e-4ea5-856f-a1accb0121d1').and_return(sponsor)
-      allow(Folio::ServicePoint).to receive_messages(all: service_points)
+      allow(Folio::Types).to receive_messages(service_points: Folio::TypeStore.new(Folio::ServicePoint, service_points))
     end
 
     it 'preserves the group parameter across navigation' do

--- a/spec/features/proxy_user_spec.rb
+++ b/spec/features/proxy_user_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe 'Proxy User' do
     allow(FolioClient).to receive(:new) { mock_client }
     allow(mock_client).to receive_messages(patron_info:)
     allow(mock_client).to receive(:patron_info).with('ec52d62d-9f0e-4ea5-856f-a1accb0121d1').and_return(sponsor)
-    allow(Folio::ServicePoint).to receive_messages(all: service_points)
+    allow(Folio::Types).to receive_messages(service_points: Folio::TypeStore.new(Folio::ServicePoint, service_points))
     allow(Folio::LoanPolicy).to receive(:new).and_return(build(:grad_mono_loans))
     login_as(User.new(username: 'stub_user', patron_key: 'bdfa62a1-758c-4389-ae81-8ddb37860f9b'))
   end

--- a/spec/features/renew_item_spec.rb
+++ b/spec/features/renew_item_spec.rb
@@ -30,9 +30,7 @@ RSpec.describe 'Renew item', :js do
     allow(mock_client).to receive_messages(patron_info:,
                                            renew_item_by_id: api_response,
                                            renew_items: bulk_renew_response)
-    allow(Folio::ServicePoint).to receive_messages(
-      all: service_points
-    )
+    allow(Folio::Types).to receive_messages(service_points: Folio::TypeStore.new(Folio::ServicePoint, service_points))
     allow(Folio::LoanPolicy).to receive(:new).and_return(build(:grad_mono_loans,
                                                                due_date: '2021-01-09T07:59:59.000+00:00',
                                                                renewal_count: 0))

--- a/spec/features/requests_spec.rb
+++ b/spec/features/requests_spec.rb
@@ -20,9 +20,7 @@ RSpec.describe 'Request Page' do
                                            cancel_request: api_response,
                                            change_pickup_service_point: api_response,
                                            change_pickup_expiration: api_response)
-    allow(Folio::ServicePoint).to receive_messages(
-      all: service_points
-    )
+    allow(Folio::Types).to receive_messages(service_points: Folio::TypeStore.new(Folio::ServicePoint, service_points))
 
     login_as(User.new(username: 'stub_user', patron_key: '513a9054-5897-11ee-8c99-0242ac120002'))
   end

--- a/spec/helpers/requests_helper_spec.rb
+++ b/spec/helpers/requests_helper_spec.rb
@@ -102,15 +102,16 @@ RSpec.describe RequestsHelper do
       end
 
       before do
-        allow(Folio::ServicePoint).to receive_messages(
-          find_by_id: instance_double(Folio::ServicePoint,
-                                      code: 'GREEN-LOAN',
-                                      id: 'a5dbb3dc-84f8-4eb3-8bfe-c61f74a9e92d',
-                                      is_default_for_campus: 'SUL',
-                                      is_default_pickup: true,
-                                      name: 'Green Library',
-                                      pickup_location: true)
-        )
+        allow(Folio::Types).to receive_messages(service_points: Folio::TypeStore.new(
+          Folio::ServicePoint, [instance_double(Folio::ServicePoint,
+                                                code: 'GREEN-LOAN',
+                                                id: 'a5dbb3dc-84f8-4eb3-8bfe-c61f74a9e92d',
+                                                is_default_for_campus: 'SUL',
+                                                is_default_pickup: true,
+                                                name: 'Green Library',
+                                                patron_unpermitted_for_pickup?: false,
+                                                pickup_location: true)]
+        ))
         allow(request).to receive(:restricted_pickup_service_points).and_return(nil)
       end
 
@@ -132,17 +133,17 @@ RSpec.describe RequestsHelper do
       end
 
       before do
-        allow(Folio::ServicePoint).to receive_messages(
-          find_by_id: instance_double(Folio::ServicePoint,
-                                      code: 'ARS',
-                                      id: 'faa81922-3da8-4086-a7fa-977d7d3e7977',
-                                      is_default_for_campus: nil,
-                                      is_default_pickup: false,
-                                      name: 'Archive of Recorded Sound',
-                                      unpermitted_pickup_groups: [],
-                                      pickup_location: true,
-                                      patron_unpermitted_for_pickup?: false)
-        )
+        allow(Folio::Types).to receive_messages(service_points: Folio::TypeStore.new(
+          Folio::ServicePoint, [instance_double(Folio::ServicePoint,
+                                                code: 'ARS',
+                                                id: 'faa81922-3da8-4086-a7fa-977d7d3e7977',
+                                                is_default_for_campus: nil,
+                                                is_default_pickup: false,
+                                                name: 'Archive of Recorded Sound',
+                                                unpermitted_pickup_groups: [],
+                                                pickup_location: true,
+                                                patron_unpermitted_for_pickup?: false)]
+        ))
         allow(request).to receive(:restricted_pickup_service_points).and_return(nil)
       end
 
@@ -164,15 +165,15 @@ RSpec.describe RequestsHelper do
       end
 
       before do
-        allow(Folio::ServicePoint).to receive_messages(
-          find_by_id: instance_double(Folio::ServicePoint,
-                                      code: 'CLASSICS',
-                                      id: '8bb5d494-263f-42f0-9a9f-70451530d8a3',
-                                      is_default_for_campus: nil,
-                                      is_default_pickup: false,
-                                      name: 'Classics Library',
-                                      pickup_location: false)
-        )
+        allow(Folio::Types).to receive_messages(service_points: Folio::TypeStore.new(
+          Folio::ServicePoint, [instance_double(Folio::ServicePoint,
+                                                code: 'CLASSICS',
+                                                id: '8bb5d494-263f-42f0-9a9f-70451530d8a3',
+                                                is_default_for_campus: nil,
+                                                is_default_pickup: false,
+                                                name: 'Classics Library',
+                                                pickup_location: false)]
+        ))
         allow(request).to receive(:restricted_pickup_service_points).and_return(nil)
       end
 

--- a/spec/models/folio/library_spec.rb
+++ b/spec/models/folio/library_spec.rb
@@ -18,34 +18,6 @@ RSpec.describe Folio::Library do
     }.with_indifferent_access
   end
 
-  # rubocop: disable Rails/RedundantActiveRecordAllMethod
-  describe '.all' do
-    it 'returns an array of libraries' do
-      expect(described_class.all.first).to be_a described_class
-    end
-  end
-  # rubocop: enable Rails/RedundantActiveRecordAllMethod
-
-  describe '.find_by_code' do
-    it 'returns a library' do
-      expect(described_class.find_by_code('GREEN')).to be_a described_class
-    end
-
-    it 'returns nil for an unknown code' do
-      expect(described_class.find_by_code('SOME_CODE')).to be_nil
-    end
-  end
-
-  describe '.find_by_id' do
-    it 'returns a library' do
-      expect(described_class.find_by_id('c1a86906-ced0-46cb-8f5b-8cef542bdd00')).to be_a described_class
-    end
-
-    it 'returns nil for an unknown code' do
-      expect(described_class.find_by_id('123456')).to be_nil
-    end
-  end
-
   describe '.from_dynamic' do
     subject(:green) { described_class.from_dynamic(green_library) }
 

--- a/spec/models/folio/location_spec.rb
+++ b/spec/models/folio/location_spec.rb
@@ -31,34 +31,6 @@ RSpec.describe Folio::Location do
     }.with_indifferent_access
   end
 
-  # rubocop: disable Rails/RedundantActiveRecordAllMethod
-  describe '.all' do
-    it 'returns an array of locations' do
-      expect(described_class.all.first).to be_a described_class
-    end
-  end
-  # rubocop: enable Rails/RedundantActiveRecordAllMethod
-
-  describe '.find_by_code' do
-    it 'returns a location' do
-      expect(described_class.find_by_code('GRE-STACKS')).to be_a described_class
-    end
-
-    it 'returns nil for an unknown code' do
-      expect(described_class.find_by_code('SOME_CODE')).to be_nil
-    end
-  end
-
-  describe '.find_by_id' do
-    it 'returns a location' do
-      expect(described_class.find_by_id('4573e824-9273-4f13-972f-cff7bf504217')).to be_a described_class
-    end
-
-    it 'returns nil for an unknown code' do
-      expect(described_class.find_by_id('f5c58187-3db6-4bda-b1bf-e5f0717e2149')).to be_nil
-    end
-  end
-
   describe '.from_dynamic' do
     subject(:green) { described_class.from_dynamic(green_reserves) }
 

--- a/spec/models/folio/request_spec.rb
+++ b/spec/models/folio/request_spec.rb
@@ -111,7 +111,7 @@ RSpec.describe Folio::Request do
     end
 
     before do
-      allow(Folio::ServicePoint).to receive_messages(all: service_points)
+      allow(Folio::Types).to receive_messages(service_points: Folio::TypeStore.new(Folio::ServicePoint, service_points))
     end
 
     context 'when the code maps to a service point' do

--- a/spec/models/folio/service_point_spec.rb
+++ b/spec/models/folio/service_point_spec.rb
@@ -8,22 +8,8 @@ RSpec.describe Folio::ServicePoint do
   end
 
   before do
-    allow(described_class).to receive_messages(
-      all: service_points
-    )
+    allow(Folio::Types).to receive_messages(service_points: Folio::TypeStore.new(described_class, service_points))
   end
-
-  # rubocop: disable Rails/RedundantActiveRecordAllMethod
-  describe '.all' do
-    it 'returns an array of service points' do
-      expect(described_class.all.first).to be_a described_class
-    end
-
-    it 'returns all the service points' do
-      expect(described_class.all.size).to eq(4)
-    end
-  end
-  # rubocop: enable Rails/RedundantActiveRecordAllMethod
 
   describe '.default_service_points' do
     it 'returns only the default service points' do
@@ -38,16 +24,6 @@ RSpec.describe Folio::ServicePoint do
 
     it 'returns nil for an unknown code' do
       expect(described_class.name_by_code('FAKELIB')).to be_nil
-    end
-  end
-
-  describe '.find_by_id' do
-    it 'returns the service point' do
-      expect(described_class.find_by_id('a5dbb3dc-84f8-4eb3-8bfe-c61f74a9e92d')).to be_a described_class
-    end
-
-    it 'returns nil for an unknown id' do
-      expect(described_class.find_by_id('fake-123-345')).to be_nil
     end
   end
 end


### PR DESCRIPTION
This brings the location modeling in-sync with requests, hopefully making it easier to lift other models over without as much change. 